### PR TITLE
fix typo in vtable example

### DIFF
--- a/proposals/gc/Overview.md
+++ b/proposals/gc/Overview.md
@@ -122,9 +122,9 @@ class D extends C {
 (type $h-sig (func (param (ref $D)) (result i32)))
 
 (type $C (struct (ref $C-vt) (mut i32))
-(type $C-vt (struct (ref $f-sig) (ref $gh-sig)))    ;; all immutable
+(type $C-vt (struct (ref $f-sig) (ref $g-sig)))     ;; all immutable
 (type $D (struct (ref $D-vt) (mut i32) (mut f64)))  ;; subtype of $C
-(type $D-vt (struct (extend $C-vt) (ref $g-sig)))   ;; immutable, subtype of $C-vt
+(type $D-vt (struct (extend $C-vt) (ref $h-sig)))   ;; immutable, subtype of $C-vt
 ```
 (Note: the use of `extend` in this example and others is assumed to be simple syntactic sugar for expanding the referenced structure type in place; subtyping still is meant to defined [structurally](#subtyping).)
 


### PR DESCRIPTION
Fixes a minor typo in the vtable example.