### PR TITLE
Make ref.cast succeed on null

### DIFF
--- a/proposals/gc/MVP.md
+++ b/proposals/gc/MVP.md
@@ -382,10 +382,12 @@ RTT-based casts can only be performed with respect to concrete types, and requir
   - returns 1 if the first operand is not null and its runtime type is a sub-RTT of the RTT operand, 0 otherwise
 
 * `ref.cast <typeidx>` casts a reference value down to a type given by a RTT representation
-  - `ref.cast $t : [(ref null ht) (rtt n? $t)] -> [(ref $t)]`
+  - `ref.cast $t : [(ref null1? ht) (rtt n? $t)] -> [(ref null2? $t)]`
     - iff `ht <: data` or `ht <: func`
     - and `(type $t) <: ht`
-  - traps if the first operand is null or its runtime type is not a sub-RTT of the RTT operand
+    - and `null1? = null2?`
+  - returns null if the first operand is null
+  - traps if the first operand is not null and its runtime type is not a sub-RTT of the RTT operand
 
 * `br_on_cast <labelidx> <typeidx>` branches if a value can be cast down to a given reference type
   - `br_on_cast $l $t : [(ref null ht) (rtt n? $t)] -> [(ref null ht)]`


### PR DESCRIPTION
This changes `ref.cast` to propagate null instead of trapping. Addresses #152.

(For now, not introducing two variants of the instruction -- let's see how common the other case really is to justify duplication.)