### PR TITLE
Remove parametric polymorphism from Post-MVP

### DIFF
--- a/proposals/gc/Overview.md
+++ b/proposals/gc/Overview.md
@@ -335,7 +335,7 @@ Unless willing to implement runtime code specialisation (like C# / .NET) a type-
 
 The usual implementation technique is a uniform representation, potentially refined with local unboxing and type specialisation optimisations.
 
-The MVP proposal does not directly support parametric polymorphism (see the discussion of [type parameters and fields](#type-parameters-and-fields) below for its discussion as an extension).
+The MVP proposal is unlikely to be extended with direct support parametric polymorphism (due to issues with decidability summarized in the [Post-MVP](Ppst-MVP.md#fundamental-limitations)).
 However, compilation with a uniform representation can still be achieved in this proposal by consistently using the type  `anyref`, which is the super type of all references, and then down-cast from there:
 ```
 (type $pair (struct anyref anyref))
@@ -375,8 +375,6 @@ However, compilation with a uniform representation can still be achieved in this
 ```
 Note how type [`i31ref`](#tagged-integers) avoids Boolean values to be heap-allocated.
 Also note how a down cast is necessary to recover the original type after a value has been passed through (the compiled form of) a polymorphic function like `g` -- the compiler knows the type but Wasm does not.
-
-(Future versions of Wasm should support [type parameters](#type-parameters-and-fields) to make such use cases more efficient and avoid the excessive use of runtime types to compile source language polymorphism, but for the GC MVP this provides the necessary expressiveness.)
 
 Needs:
 * `anyref`
@@ -773,7 +771,7 @@ There are a number of reasons to make RTTs explicit:
 
 * It allows more choice in producers' use of RTT information, including making it optional (post-MVP), in accordance with the pay-as-you-go principle: for example, structs that are not involved in any casts do not need to pay the overhead of carrying runtime type information (depending on specifics of the GC implementation strategy). Some languages may never need to introduce any RTTs at all.
 
-* Most importantly, making RTTs explicit separates the concerns of casting from Wasm-level polymorphism, i.e., [type parameters and fields](#type-paraemters-and-fields). Type parameters can thus be treated as purely a validation artifact with no bearing on runtime. This property, known as parametricity, drastically simplifies the implementation of such type parameterisation and avoids the substantial hidden costs of reified generics that would otherwise hvae to be paid for every single use of type parameters (short of non-trivial cross-procedural dataflow analysis in the engine).
+* Most importantly, making RTTs explicit separates the concerns of casting from Wasm-level polymorphism, i.e., [type parameters and fields](#type-paraemters-and-fields). Type parameters can thus be treated as purely a validation artifact with no bearing on runtime. This property, known as erasure, drastically simplifies the implementation of such type parameterisation and avoids the substantial hidden costs of reified generics that would otherwise have to be paid for every single use of type parameters (short of non-trivial cross-procedural dataflow analysis in the engine).
 
 
 ## Future Extensions

--- a/proposals/gc/Post-MVP.md
+++ b/proposals/gc/Post-MVP.md
@@ -403,6 +403,16 @@ However, there are a number of challenges:
 
 In general, the semantics and implementation of type parameters should be analogous to that of type imports. Ideally, in the presence of the [module linking proposal](https://github.com/WebAssembly/module-linking), it should even be possible to explain definitions with type parameters as shorthands for nested modules (well, at least for 2nd-class cases).
 
+### Fundamental Limitations
+
+Unfortunately, languages with generics exhibit one or both of the following features:
+* Expansive-recursive structures, such as `datatype 'a T = EMPTY | NODE of 'a * (('a T) T)` in ML
+* Impredicative bounded polymorphism, such as bounded generic methods in C#, or the bounded existential types used to describe (at the assembly level) Java/C# covariant arrays or Kotlin `in`/`out` type projections.
+
+Each of these features is undecidable on its own, and although the respective surface languages are decidable, their low-level encoding as structural types is not.
+As such, it is unlikely that the MVP will be able to be extended to support languages with generics.
+Nonetheless, we might find other uses for parametric polymorphism, and the following offers an impression of what such an extension might look like.
+
 ### Sketch
 
 * Allow type parameters on function types:

--- a/proposals/gc/Post-MVP.md
+++ b/proposals/gc/Post-MVP.md
@@ -410,7 +410,7 @@ Unfortunately, languages with generics exhibit one or both of the following feat
 * Impredicative bounded polymorphism, such as bounded generic methods in C#, or the bounded existential types used to describe (at the assembly level) Java/C# covariant arrays or Kotlin `in`/`out` type projections.
 
 Each of these features is undecidable on its own, and although the respective surface languages are decidable, their low-level encoding as structural types is not.
-As such, it is unlikely that the MVP will be able to be extended to support languages with generics.
+As such, it is unlikely that the MVP will be able to be extended to support cast-free implementations of languages with generics, though the MVP might be extended with built-in support for common special cases of generics such as covariant arrays.
 Nonetheless, we might find other uses for parametric polymorphism, and the following offers an impression of what such an extension might look like.
 
 ### Sketch

--- a/proposals/gc/Post-MVP.md
+++ b/proposals/gc/Post-MVP.md
@@ -409,7 +409,7 @@ Unfortunately, languages with generics exhibit one or both of the following feat
 * Expansive-recursive structures, such as `datatype 'a T = EMPTY | NODE of 'a * (('a T) T)` in ML
 * Impredicative bounded polymorphism, such as bounded generic methods in C#, or the bounded existential types used to describe (at the assembly level) Java/C# covariant arrays or Kotlin `in`/`out` type projections.
 
-Each of these features is undecidable on its own, and although the respective surface languages are decidable, their low-level encoding as structural types is not.
+Adding either of these features to the MVP's existing subtyping system with enough expressiveness to capture their use in the respective surface languages would be undecidable even though the respective surface languages are decidable.
 As such, it is unlikely that the MVP will be able to be extended to support cast-free implementations of languages with generics, though the MVP might be extended with built-in support for common special cases of generics such as covariant arrays.
 Nonetheless, we might find other uses for parametric polymorphism, and the following offers an impression of what such an extension might look like.
 


### PR DESCRIPTION
The Post-MVP proposes to add parameteric polymorphism for the sake of supporting generics. However, #156 provided multiple reasons why the Post-MVP would not be able to express languages with generics (both OO and functional, reified and erased)&mdash;in three months, no counterarguments to these claims were ever provided. And in my recent presentations I gave multiple reasons why any structural type system that would be rich enough to express common languages with generics would also necessarily be undecidable. As such, the section on parametric polymorphism in the Post-MVP should be removed as it cannot be reasonably expected to serve its intended purpose.