### PR TITLE
[interpreter] Implement types

### DIFF
--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -52,6 +52,11 @@ let num_type = function
   | "f64" -> Types.F64Type
   | _ -> assert false
 
+let packed_type = function
+  | "i8" -> Types.I8Type
+  | "i16" -> Types.I16Type
+  | _ -> assert false
+
 let intop t i32 i64 =
   match t with
   | "i32" -> i32
@@ -140,6 +145,7 @@ let name = '$' reserved
 let ixx = "i" ("32" | "64")
 let fxx = "f" ("32" | "64")
 let nxx = ixx | fxx
+let pixx = "i" ("8" | "16")
 let mixx = "i" ("8" | "16" | "32" | "64")
 let mfxx = "f" ("32" | "64")
 let sign = "s" | "u"
@@ -161,12 +167,25 @@ rule token = parse
     { error_nest (Lexing.lexeme_end_p lexbuf) lexbuf "illegal escape" }
 
   | "ref" { REF }
+  | "rtt" { RTT }
   | "null" { NULL }
+  | "any" { ANY }
+  | "anyref" { ANYREF }
+  | "eq" { EQ }
+  | "eqref" { EQREF }
+  | "i31" { I31 }
+  | "i31ref" { I31REF }
+  | "data" { DATA }
+  | "dataref" { DATAREF }
   | "extern" { EXTERN }
   | "externref" { EXTERNREF }
   | "funcref" { FUNCREF }
   | (nxx as t) { NUM_TYPE (num_type t) }
+  | (pixx as t) { PACKED_TYPE (packed_type t) }
   | "mut" { MUT }
+  | "field" { FIELD }
+  | "struct" { STRUCT }
+  | "array" { ARRAY }
 
   | (nxx as t)".const"
     { let open Source in

--- a/interpreter/valid/match.ml
+++ b/interpreter/valid/match.ml
@@ -35,6 +35,8 @@ let rec eq_num_type c a t1 t2 =
 and eq_heap_type c a t1 t2 =
   match t1, t2 with
   | DefHeapType x1, DefHeapType x2 -> eq_var_type c a x1 x2
+  | RttHeapType (x1, no1), RttHeapType (x2, no2) ->
+    eq_var_type c a x1 x2 && no1 = no2
   | _, _ -> t1 = t2
 
 and eq_ref_type c a t1 t2 =
@@ -52,12 +54,34 @@ and eq_stack_type c a ts1 ts2 =
   List.length ts1 = List.length ts2 &&
   List.for_all2 (eq_value_type c a) ts1 ts2
 
+and eq_packed_type c a t1 t2 =
+  t1 = t2
+
+and eq_storage_type c a st1 st2 =
+  match st1, st2 with
+  | ValueStorageType t1, ValueStorageType t2 -> eq_value_type c a t1 t2
+  | PackedStorageType t1, PackedStorageType t2 -> eq_packed_type c a t1 t2
+  | _, _ -> false
+
+and eq_field_type c a (FieldType (st1, mut1)) (FieldType (st2, mut2)) =
+  eq_storage_type c a st1 st2 && eq_mutability c a mut1 mut2
+
+and eq_struct_type c a (StructType fts1) (StructType fts2) =
+  List.length fts1 = List.length fts2 &&
+  List.for_all2 (eq_field_type c a) fts1 fts2
+
+and eq_array_type c a (ArrayType ft1) (ArrayType ft2) =
+  eq_field_type c a ft1 ft2
+
 and eq_func_type c a (FuncType (ts11, ts12)) (FuncType (ts21, ts22)) =
   eq_stack_type c a ts11 ts21 && eq_stack_type c a ts12 ts22
 
 and eq_def_type c a dt1 dt2 =
   match dt1, dt2 with
+  | StructDefType st1, StructDefType st2 -> eq_struct_type c a st1 st2
+  | ArrayDefType at1, ArrayDefType at2 -> eq_array_type c a at1 at2
   | FuncDefType ft1, FuncDefType ft2 -> eq_func_type c a ft1 ft2
+  | _, _ -> false
 
 and eq_var_type c a x1 x2 =
   equal_var x1 x2 || assuming a (x1, x2) ||
@@ -101,11 +125,21 @@ let rec match_num_type c a t1 t2 =
 
 and match_heap_type c a t1 t2 =
   match t1, t2 with
+  | _, AnyHeapType -> true
+  | I31HeapType, EqHeapType -> true
+  | DataHeapType, EqHeapType -> true
+  | DefHeapType x1, DataHeapType ->
+    (match lookup c x1 with
+    | StructDefType _ | ArrayDefType _ -> true
+    | _ -> false
+    )
   | DefHeapType x1, FuncHeapType ->
     (match lookup c x1 with
     | FuncDefType _ -> true
+    | _ -> false
     )
   | DefHeapType x1, DefHeapType x2 -> match_var_type c a x1 x2
+  | RttHeapType (x1, Some _), RttHeapType (x2, None) -> eq_var_type c [] x1 x2
   | BotHeapType, _ -> true
   | _, _ -> eq_heap_type c [] t1 t2
 
@@ -124,6 +158,29 @@ and match_value_type c a t1 t2 =
 and match_stack_type c a ts1 ts2 =
   List.length ts1 = List.length ts2 &&
   List.for_all2 (match_value_type c a) ts1 ts2
+
+and match_packed_type c a t1 t2 =
+  t1 = t2
+
+and match_storage_type c a st1 st2 =
+  match st1, st2 with
+  | ValueStorageType t1, ValueStorageType t2 -> match_value_type c a t1 t2
+  | PackedStorageType t1, PackedStorageType t2 -> match_packed_type c a t1 t2
+  | _, _ -> false
+
+and match_field_type c a (FieldType (st1, mut1)) (FieldType (st2, mut2)) =
+  eq_mutability c [] mut1 mut2 &&
+  match mut1 with
+  | Immutable -> match_storage_type c a st1 st2
+  | Mutable -> eq_storage_type c [] st1 st2
+
+and match_struct_type c a (StructType fts1) (StructType fts2) =
+  List.length fts1 >= List.length fts2 &&
+  List.for_all2 (match_field_type c a)
+    (Lib.List.take (List.length fts2) fts1) fts2
+
+and match_array_type c a (ArrayType ft1) (ArrayType ft2) =
+  match_field_type c a ft1 ft2
 
 and match_func_type c a ft1 ft2 =
   eq_func_type c [] ft1 ft2
@@ -150,7 +207,10 @@ and match_extern_type c a et1 et2 =
 
 and match_def_type c a dt1 dt2 =
   match dt1, dt2 with
+  | StructDefType st1, StructDefType st2 -> match_struct_type c a st1 st2
+  | ArrayDefType at1, ArrayDefType at2 -> match_array_type c a at1 at2
   | FuncDefType ft1, FuncDefType ft2 -> match_func_type c a ft1 ft2
+  | _, _ -> false
 
 and match_var_type c a x1 x2 =
   equal_var x1 x2 || assuming a (x1, x2) ||

--- a/test/core/array.wast
+++ b/test/core/array.wast
@@ -1,0 +1,34 @@
+(module
+  (type (array i8))
+  (type (array i16))
+  (type (array i32))
+  (type (array i64))
+  (type (array f32))
+  (type (array f64))
+  (type (array anyref))
+  (type (array (ref data)))
+  (type (array (ref 0)))
+  (type (array (ref null 1)))
+  (type (array (rtt 1)))
+  (type (array (rtt 10 1)))
+  (type (array (mut i8)))
+  (type (array (mut i16)))
+  (type (array (mut i32)))
+  (type (array (mut i64)))
+  (type (array (mut i32)))
+  (type (array (mut i64)))
+  (type (array (mut anyref)))
+  (type (array (mut (ref data))))
+  (type (array (mut (ref 0))))
+  (type (array (mut (ref null i31))))
+  (type (array (mut (rtt 0))))
+  (type (array (mut (rtt 10 0))))
+)
+
+
+(assert_invalid
+  (module
+    (type (array (mut (ref null 10))))
+  )
+  "unknown type"
+)

--- a/test/core/struct.wast
+++ b/test/core/struct.wast
@@ -1,0 +1,18 @@
+(module
+  (type (struct))
+  (type (struct (field)))
+  (type (struct (field i8)))
+  (type (struct (field i8 i8 i8 i8)))
+  (type (struct (field $x i32) (field $y i32)))
+  (type (struct (field i8 i16 i32 i64 f32 f64 anyref funcref (ref 0) (ref null 1))))
+  (type (struct (field i32 i64 i8) (field) (field) (field (ref null i31) anyref)))
+  (type (struct (field $x i32) (field f32 f64) (field $y i32)))
+)
+
+
+(assert_invalid
+  (module
+    (type (struct (field (mut (ref null 10)))))
+  )
+  "unknown type"
+)


### PR DESCRIPTION
This extends the interpreter with all the added type structure from the proposal, i.e., type en/decoding, text parsing/printing, validation of type definitions, etc. Includes a few simple tests for type definitions.

Instructions to follow.