### PR TITLE
Fix nullability in decoding of rtt ref

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -179,8 +179,8 @@ let ref_type s =
   | -0x14l -> (Nullable, heap_type s)
   | -0x15l -> (NonNullable, heap_type s)
   | -0x16l -> (Nullable, I31HeapType)
-  | -0x17l -> let n = vu32 s in (Nullable, RttHeapType (var_type s, Some n))
-  | -0x18l -> (Nullable, RttHeapType (var_type s, None))
+  | -0x17l -> let n = vu32 s in (NonNullable, RttHeapType (var_type s, Some n))
+  | -0x18l -> (NonNullable, RttHeapType (var_type s, None))
   | -0x19l -> (Nullable, DataHeapType)
   | _ -> error s pos "malformed reference type"
 


### PR DESCRIPTION
`E8` was decoded as `(ref null (rtt ...))` but should be `(ref (rtt ...))`.