### PR TITLE
Fix handling of recursive function types

### DIFF
--- a/interpreter/host/env.ml
+++ b/interpreter/host/env.ml
@@ -39,13 +39,11 @@ let exit vs =
   exit (int (single vs))
 
 
-let alloc_func f ft =
-  let x = Types.alloc_uninit () in
-  Types.init x (RecCtxType ([(SemVar x, SubType ([], FuncDefType ft))], 0l));
-  ExternFunc (Func.alloc_host x f)
+let alloc_func f x =
+  ExternFunc (Func.alloc_host (as_sem_var x) f)
 
 let lookup name et =
   match Utf8.encode name, et with
-  | "abort", ExternFuncType ft -> alloc_func abort ft
-  | "exit", ExternFuncType ft -> alloc_func exit ft
+  | "abort", ExternFuncType x -> alloc_func abort x
+  | "exit", ExternFuncType x -> alloc_func exit x
   | _ -> raise Not_found

--- a/interpreter/host/spectest.ml
+++ b/interpreter/host/spectest.ml
@@ -60,5 +60,6 @@ let lookup name t =
   | "global_f64", _ -> global (GlobalType (NumType F64Type, Immutable))
   | "table", _ -> table
   | "memory", _ -> memory
-  | "debug_print", ExternFuncType ft -> func print ft
+  | "debug_print", ExternFuncType x ->
+    func print (as_func_str_type (expand_ctx_type (def_of (as_sem_var x))))
   | _ -> raise Not_found

--- a/interpreter/runtime/instance.ml
+++ b/interpreter/runtime/instance.ml
@@ -66,7 +66,7 @@ let empty_module_inst =
     exports = []; elems = []; datas = [] }
 
 let extern_type_of c = function
-  | ExternFunc func -> ExternFuncType (Func.type_of func)
+  | ExternFunc func -> ExternFuncType (SemVar (Func.type_inst_of func))
   | ExternTable tab -> ExternTableType (Table.type_of tab)
   | ExternMemory mem -> ExternMemoryType (Memory.type_of mem)
   | ExternGlobal glob -> ExternGlobalType (Global.type_of glob)

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -214,7 +214,7 @@ type exports = extern_type NameMap.t
 type modules = {mutable env : exports Map.t; mutable current : int}
 
 let exports m : exports =
-  let ets = List.map (export_type_of m) m.it.exports in
+  let ModuleType (_, _, ets) = sem_module_type (module_type_of m) in
   List.fold_left (fun map (ExportType (et, name)) -> NameMap.add name et map)
     NameMap.empty ets
 
@@ -570,9 +570,13 @@ let of_action mods act =
     "call(" ^ of_var_opt mods x_opt ^ ", " ^ of_name name ^ ", " ^
       "[" ^ String.concat ", " (List.map of_value vs) ^ "])",
     (match lookup mods x_opt name act.at with
-    | ExternFuncType ft when not (is_js_func_type ft) ->
-      let FuncType (_, out) = ft in
-      Some (of_wrapper mods x_opt name (invoke ft vs), out)
+    | ExternFuncType x ->
+      let FuncType (_, out) as ft =
+        as_func_str_type (expand_ctx_type (def_of (as_sem_var x))) in
+      if is_js_func_type ft then
+        None
+      else
+        Some (of_wrapper mods x_opt name (invoke ft vs), out)
     | _ -> None
     )
   | Get (x_opt, name) ->

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -352,27 +352,11 @@ let empty_module =
 
 open Source
 
-let func_type_of (m : module_) (x : idx) : func_type =
-  let rec find_in_def_types dts i =
-    match dts with
-    | dt::dts' ->
-      (match dt.it with
-      | RecDefType sts -> find_in_sub_types sts i dts'
-      )
-    | [] -> failwith "func_type_of"
-  and find_in_sub_types sts i dts =
-    let n = Lib.List32.length sts in
-    if i < n then
-      let SubType (_, st) = Lib.List32.nth sts i in st
-    else
-      find_in_def_types dts (Int32.sub i n)
-  in as_func_str_type (find_in_def_types m.it.types x.it)
-
 let import_type_of (m : module_) (im : import) : import_type =
   let {idesc; module_name; item_name} = im.it in
   let et =
     match idesc.it with
-    | FuncImport x -> ExternFuncType (func_type_of m x)
+    | FuncImport x -> ExternFuncType (SynVar x.it)
     | TableImport t -> ExternTableType t
     | MemoryImport t -> ExternMemoryType t
     | GlobalImport t -> ExternGlobalType t
@@ -386,9 +370,8 @@ let export_type_of (m : module_) (ex : export) : export_type =
   let et =
     match edesc.it with
     | FuncExport x ->
-      let fts =
-        funcs ets @ List.map (fun f -> func_type_of m f.it.ftype) m.it.funcs
-      in ExternFuncType (nth fts x.it)
+      let fts = funcs ets @ List.map (fun f -> SynVar f.it.ftype.it) m.it.funcs in
+      ExternFuncType (nth fts x.it)
     | TableExport x ->
       let tts = tables ets @ List.map (fun t -> t.it.ttype) m.it.tables in
       ExternTableType (nth tts x.it)

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -51,7 +51,7 @@ type table_type = TableType of Int32.t limits * ref_type
 type memory_type = MemoryType of Int32.t limits
 type global_type = GlobalType of value_type * mutability
 type extern_type =
-  | ExternFuncType of func_type
+  | ExternFuncType of var
   | ExternTableType of table_type
   | ExternMemoryType of memory_type
   | ExternGlobalType of global_type
@@ -262,7 +262,7 @@ let subst_global_type s (GlobalType (t, mut)) =
   GlobalType (subst_value_type s t, mut)
 
 let subst_extern_type s = function
-  | ExternFuncType ft -> ExternFuncType (subst_func_type s ft)
+  | ExternFuncType x -> ExternFuncType (s x)
   | ExternTableType tt -> ExternTableType (subst_table_type s tt)
   | ExternMemoryType mt -> ExternMemoryType (subst_memory_type s mt)
   | ExternGlobalType gt -> ExternGlobalType (subst_global_type s gt)
@@ -460,7 +460,7 @@ let string_of_global_type = function
   | GlobalType (t, mut) -> string_of_mutability (string_of_value_type t) mut
 
 let string_of_extern_type = function
-  | ExternFuncType ft -> "func " ^ string_of_func_type ft
+  | ExternFuncType x -> "func " ^ string_of_var x
   | ExternTableType tt -> "table " ^ string_of_table_type tt
   | ExternMemoryType mt -> "memory " ^ string_of_memory_type mt
   | ExternGlobalType gt -> "global " ^ string_of_global_type gt

--- a/interpreter/valid/match.ml
+++ b/interpreter/valid/match.ml
@@ -125,7 +125,7 @@ and eq_global_type c (GlobalType (t1, mut1)) (GlobalType (t2, mut2)) =
 
 and eq_extern_type c et1 et2 =
   match et1, et2 with
-  | ExternFuncType ft1, ExternFuncType ft2 -> eq_func_type c ft1 ft2
+  | ExternFuncType x1, ExternFuncType x2 -> eq_var_type c x1 x2
   | ExternTableType tt1, ExternTableType tt2 -> eq_table_type c tt1 tt2
   | ExternMemoryType mt1, ExternMemoryType mt2 -> eq_memory_type c mt1 mt2
   | ExternGlobalType gt1, ExternGlobalType gt2 -> eq_global_type c gt1 gt2
@@ -241,7 +241,7 @@ and match_global_type c (GlobalType (t1, mut1)) (GlobalType (t2, mut2)) =
 
 and match_extern_type c et1 et2 =
   match et1, et2 with
-  | ExternFuncType ft1, ExternFuncType ft2 -> match_func_type c ft1 ft2
+  | ExternFuncType x1, ExternFuncType x2 -> match_var_type c x1 x2
   | ExternTableType tt1, ExternTableType tt2 -> match_table_type c tt1 tt2
   | ExternMemoryType mt1, ExternMemoryType mt2 -> match_memory_type c mt1 mt2
   | ExternGlobalType gt1, ExternGlobalType gt2 -> match_global_type c gt1 gt2

--- a/proposals/gc/MVP.md
+++ b/proposals/gc/MVP.md
@@ -121,6 +121,10 @@ Validity of a module is checked under a context storing the definitions for each
 ctxtype ::= <deftype>.<i>
 ```
 
+Both `C.types` and `C.funcs` in typing contexts `C` as defined by the spec now carry `ctxtype`s as opposed to `functype`s like before.
+In the case of `C.funcs`, it is an invariant that all types [expand](#auxiliary-definitions) to a function type.
+
+
 #### Auxiliary Definitions
 
 * Unpacking a storage type yields `i32` for packed types, otherwise the type itself
@@ -135,6 +139,15 @@ ctxtype ::= <deftype>.<i>
   - `expand($t)                 = expand(<ctxtype>)`  iff `$t = <ctxtype>`
   - `expand(<ctxtype>) = <strtype>`
     - where `unroll(<ctxttype>) = sub x* <strtype>`
+
+
+#### External Types
+
+Unlike in the current spec, external function types need to be represented by a type index/address, in order to preserve the structure and equivalence of iso-recursive types:
+```
+externtype ::= func <typeidx> | ...
+```
+The type is then looked up and expanded as needed. (This was `func <functype>` before.)
 
 
 #### Type Validity

--- a/test/core/type-rec.wast
+++ b/test/core/type-rec.wast
@@ -1,0 +1,88 @@
+;; Static matching of recursive function types
+
+(module
+  (rec (type $f1 (func)) (type (struct)))
+  (rec (type $f2 (func)) (type (struct)))
+  (global (ref $f1) (ref.func $f))
+  (func $f (type $f2))
+)
+
+(assert_invalid
+  (module
+    (rec (type $f1 (func)) (type (struct)))
+    (rec (type (struct)) (type $f2 (func)))
+    (global (ref $f1) (ref.func $f))
+    (func $f (type $f2))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (rec (type $f1 (func)) (type (struct)))
+    (rec (type $f2 (func)) (type (struct)) (type (func)))
+    (global (ref $f1) (ref.func $f))
+    (func $f (type $f2))
+  )
+  "type mismatch"
+)
+
+
+;; Link-time matching of recursive function types
+
+(module $M
+  (rec (type $f1 (func)) (type (struct)))
+  (func (export "f") (type $f1))
+)
+(register "M" $M)
+
+(module
+  (rec (type $f2 (func)) (type (struct)))
+  (func (import "M" "f") (type $f2))
+)
+
+(assert_unlinkable
+  (module
+    (rec (type (struct)) (type $f2 (func)))
+    (func (import "M" "f") (type $f2))
+  )
+  "incompatible import type"
+)
+
+(assert_unlinkable
+  (module
+    (rec (type $f2 (func)))
+    (func (import "M" "f") (type $f2))
+  )
+  "incompatible import type"
+)
+
+
+;; Dynamic matching of recursive function types
+
+(module
+  (rec (type $f1 (func)) (type (struct)))
+  (rec (type $f2 (func)) (type (struct)))
+  (table funcref (elem $f1))
+  (func $f1 (type $f1))
+  (func (export "run") (call_indirect (type $f2) (i32.const 0)))
+)
+(assert_return (invoke "run"))
+
+(module
+  (rec (type $f1 (func)) (type (struct)))
+  (rec (type (struct)) (type $f2 (func)))
+  (table funcref (elem $f1))
+  (func $f1 (type $f1))
+  (func (export "run") (call_indirect (type $f2) (i32.const 0)))
+)
+(assert_trap (invoke "run") "indirect call type mismatch")
+
+(module
+  (rec (type $f1 (func)) (type (struct)))
+  (rec (type $f2 (func)))
+  (table funcref (elem $f1))
+  (func $f1 (type $f1))
+  (func (export "run") (call_indirect (type $f2) (i32.const 0)))
+)
+(assert_trap (invoke "run") "indirect call type mismatch")


### PR DESCRIPTION
Correct typing of functions in context and external types to track vars instead of expanded function types, so that iso-recursive equality is preserved.

Adds tests as well.

Fixes #290.