### PR TITLE
Add nullref

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -173,12 +173,12 @@ let heap_type s =
     (match vs7 s with
     | -0x10 -> FuncHeapType
     | -0x11 -> AnyHeapType
-    | -0x12 -> NoneHeapType
     | -0x13 -> EqHeapType
     | -0x16 -> I31HeapType
     | -0x18 -> RttHeapType (var_type s)
     | -0x19 -> DataHeapType
     | -0x1a -> ArrayHeapType
+    | -0x1b -> NoneHeapType
     | _ -> error s pos "malformed heap type"
     )
   | _ ->
@@ -191,7 +191,6 @@ let ref_type s =
   match vs7 s with
   | -0x10 -> (Nullable, FuncHeapType)
   | -0x11 -> (Nullable, AnyHeapType)
-  | -0x12 -> (Nullable, NoneHeapType)
   | -0x13 -> (Nullable, EqHeapType)
   | -0x14 -> (Nullable, heap_type s)
   | -0x15 -> (NonNullable, heap_type s)
@@ -199,6 +198,7 @@ let ref_type s =
   | -0x18 -> (NonNullable, RttHeapType (var_type s))
   | -0x19 -> (Nullable, DataHeapType)
   | -0x1a -> (Nullable, ArrayHeapType)
+  | -0x1b -> (Nullable, NoneHeapType)
   | _ -> error s pos "malformed reference type"
 
 let value_type s =

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -173,6 +173,7 @@ let heap_type s =
     (match vs7 s with
     | -0x10 -> FuncHeapType
     | -0x11 -> AnyHeapType
+    | -0x12 -> NoneHeapType
     | -0x13 -> EqHeapType
     | -0x16 -> I31HeapType
     | -0x18 -> RttHeapType (var_type s)
@@ -190,6 +191,7 @@ let ref_type s =
   match vs7 s with
   | -0x10 -> (Nullable, FuncHeapType)
   | -0x11 -> (Nullable, AnyHeapType)
+  | -0x12 -> (Nullable, NoneHeapType)
   | -0x13 -> (Nullable, EqHeapType)
   | -0x14 -> (Nullable, heap_type s)
   | -0x15 -> (NonNullable, heap_type s)

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -110,7 +110,7 @@ struct
     | V128Type -> vs7 (-0x05)
 
   let heap_type = function
-    | NoneHeapType -> vs7 (-0x12)
+    | NoneHeapType -> vs7 (-0x1b)
     | AnyHeapType -> vs7 (-0x11)
     | EqHeapType -> vs7 (-0x13)
     | I31HeapType -> vs7 (-0x16)
@@ -121,7 +121,7 @@ struct
     | RttHeapType x -> vs7 (-0x18); var_type vu32 x
 
   let ref_type = function
-    | (Nullable, NoneHeapType) -> vs7 (-0x12)
+    | (Nullable, NoneHeapType) -> vs7 (-0x1b)
     | (Nullable, AnyHeapType) -> vs7 (-0x11)
     | (Nullable, EqHeapType) -> vs7 (-0x13)
     | (Nullable, I31HeapType) -> vs7 (-0x16)

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -110,6 +110,7 @@ struct
     | V128Type -> vs7 (-0x05)
 
   let heap_type = function
+    | NoneHeapType -> vs7 (-0x12)
     | AnyHeapType -> vs7 (-0x11)
     | EqHeapType -> vs7 (-0x13)
     | I31HeapType -> vs7 (-0x16)
@@ -118,9 +119,9 @@ struct
     | FuncHeapType -> vs7 (-0x10)
     | DefHeapType x -> var_type vs33 x
     | RttHeapType x -> vs7 (-0x18); var_type vu32 x
-    | BotHeapType -> assert false
 
   let ref_type = function
+    | (Nullable, NoneHeapType) -> vs7 (-0x12)
     | (Nullable, AnyHeapType) -> vs7 (-0x11)
     | (Nullable, EqHeapType) -> vs7 (-0x13)
     | (Nullable, I31HeapType) -> vs7 (-0x16)

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -382,6 +382,7 @@ let assert_return ress ts at =
     | RefResult (RefTypePat t) ->
       let is_ref =
         match t with
+        | NoneHeapType -> Const (I32 0l @@ at)
         | AnyHeapType -> Const (I32 1l @@ at)
         | EqHeapType -> Call (is_eqref_idx @@ at)
         | I31HeapType -> RefTest I31Op
@@ -390,7 +391,6 @@ let assert_return ress ts at =
         | FuncHeapType -> RefTest FuncOp
         | DefHeapType _ -> Const (I32 1l @@ at) (* TODO *)
         | RttHeapType _ -> Const (I32 1l @@ at) (* TODO *)
-        | BotHeapType -> assert false
       in
       [ is_ref @@ at;
         Test (I32 I32Op.Eqz) @@ at;

--- a/interpreter/syntax/free.ml
+++ b/interpreter/syntax/free.ml
@@ -73,8 +73,8 @@ let vec_type = function
   | V128Type -> empty
 
 let heap_type = function
-  | AnyHeapType | EqHeapType | I31HeapType | DataHeapType | ArrayHeapType
-  | FuncHeapType | BotHeapType -> empty
+  | NoneHeapType | AnyHeapType | EqHeapType
+  | I31HeapType | DataHeapType | ArrayHeapType | FuncHeapType -> empty
   | DefHeapType x | RttHeapType x -> var_type x
 
 let ref_type = function

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -15,6 +15,7 @@ and num_type = I32Type | I64Type | F32Type | F64Type
 and vec_type = V128Type
 and ref_type = nullability * heap_type
 and heap_type =
+  | NoneHeapType
   | AnyHeapType
   | EqHeapType
   | I31HeapType
@@ -23,7 +24,6 @@ and heap_type =
   | FuncHeapType
   | DefHeapType of var
   | RttHeapType of var
-  | BotHeapType
 and value_type =
   NumType of num_type | VecType of vec_type | RefType of ref_type | BotType
 
@@ -196,6 +196,7 @@ let subst_num_type s t = t
 let subst_vec_type s t = t
 
 let subst_heap_type s = function
+  | NoneHeapType -> NoneHeapType
   | AnyHeapType -> AnyHeapType
   | EqHeapType -> EqHeapType
   | I31HeapType -> I31HeapType
@@ -204,7 +205,6 @@ let subst_heap_type s = function
   | FuncHeapType -> FuncHeapType
   | DefHeapType x -> DefHeapType (s x)
   | RttHeapType x -> RttHeapType (s x)
-  | BotHeapType -> BotHeapType
 
 let subst_ref_type s = function
   | (nul, t) -> (nul, subst_heap_type s t)
@@ -381,6 +381,7 @@ and string_of_vec_type = function
   | V128Type -> "v128"
 
 and string_of_heap_type = function
+  | NoneHeapType -> "none"
   | AnyHeapType -> "any"
   | EqHeapType -> "eq"
   | I31HeapType -> "i31"
@@ -389,7 +390,6 @@ and string_of_heap_type = function
   | FuncHeapType -> "func"
   | DefHeapType x -> string_of_var x
   | RttHeapType x -> "(rtt " ^ string_of_var x ^ ")"
-  | BotHeapType -> "something"
 
 and string_of_ref_type = function
   | (nul, t) ->

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -220,6 +220,8 @@ rule token = parse
   | "ref" { REF }
   | "rtt" { RTT }
   | "null" { NULL }
+  | "none" { NONE }
+  | "nullref" { NULLREF }
   | "any" { ANY }
   | "anyref" { ANYREF }
   | "eq" { EQ }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -256,8 +256,8 @@ let inline_func_type_explicit (c : context) x ft at =
 %token LPAR RPAR
 %token NAT INT FLOAT STRING VAR
 %token NUM_TYPE PACKED_TYPE VEC_TYPE VEC_SHAPE
-%token ANYREF EQREF I31REF DATAREF ARRAYREF FUNCREF EXTERNREF
-%token ANY EQ I31 DATA REF RTT EXTERN NULL
+%token NULLREF ANYREF EQREF I31REF DATAREF ARRAYREF FUNCREF EXTERNREF
+%token NONE ANY EQ I31 DATA REF RTT EXTERN NULL
 %token MUT FIELD STRUCT ARRAY SUB REC
 %token UNREACHABLE NOP DROP SELECT
 %token BLOCK END IF THEN ELSE LOOP LET
@@ -359,6 +359,7 @@ null_opt :
   | NULL { Nullable }
 
 heap_type :
+  | NONE { fun c -> NoneHeapType }
   | ANY { fun c -> AnyHeapType }
   | EQ { fun c -> EqHeapType }
   | I31 { fun c -> I31HeapType }
@@ -371,6 +372,7 @@ heap_type :
 
 ref_type :
   | LPAR REF null_opt heap_type RPAR { fun c -> ($3, $4 c) }
+  | NULLREF { fun c -> (Nullable, NoneHeapType) }  /* Sugar */
   | ANYREF { fun c -> (Nullable, AnyHeapType) }  /* Sugar */
   | EQREF { fun c -> (Nullable, EqHeapType) }  /* Sugar */
   | I31REF { fun c -> (Nullable, I31HeapType) }  /* Sugar */

--- a/interpreter/valid/match.ml
+++ b/interpreter/valid/match.ml
@@ -154,6 +154,7 @@ and match_vec_type c t1 t2 =
 
 and match_heap_type c t1 t2 =
   match t1, t2 with
+  | NoneHeapType, _ -> true
   | _, AnyHeapType -> true
   | I31HeapType, EqHeapType -> true
   | DataHeapType, EqHeapType -> true
@@ -181,7 +182,6 @@ and match_heap_type c t1 t2 =
     | _ -> false
     )
   | DefHeapType x1, DefHeapType x2 -> match_var_type c x1 x2
-  | BotHeapType, _ -> true
   | _, _ -> eq_heap_type c t1 t2
 
 and match_ref_type c t1 t2 =

--- a/proposals/gc/MVP.md
+++ b/proposals/gc/MVP.md
@@ -49,6 +49,10 @@ Both proposals are prerequisites.
   - `heaptype ::= ... | rtt <typeidx>`
   - `rtt t ok` iff `t ok`
 
+* `none` is a new heap type
+  - `heaptype ::= ... | none`
+  - the common subtype of all referenceable types (a.k.a. the bottom heap type)
+
 * `extern` is renamed back to `any`
   - the common supertype of all referenceable types
   - the name `extern` is kept as an alias in the text format for backwards compatibility
@@ -78,6 +82,9 @@ New abbreviations are introduced for reference types in binary and text format, 
 
 * `rtt <typeidx>` is a new reference type
   - `(rtt $t) == (ref (rtt $t))`
+
+* `nullref` is a new reference type
+  - `nullref == (ref null none)`
 
 * `externref` is renamed to `anyref`
   - `anyref == (ref null any)`
@@ -291,6 +298,9 @@ In addition to the [existing rules](https://github.com/WebAssembly/function-refe
 * every type is a subtype of `any`
   - `t <: any`
 
+* every type is a supertype of `none`
+  - `none <: t`
+
 * `dataref` is a subtype of `eqref`
   - `data <: eq`
   - TODO: provide a way to make data types non-eq, especially immutable ones?
@@ -326,7 +336,8 @@ i31  data
        array
 ```
 All *concrete* heap types (of the form `(type $t)`) are situated below either `data` or `func`.
-RTTs are below `eq`.
+Not shown in the graph are RTTs, which are below `eq`,
+and `none` which is below every other "leaf" type.
 
 In addition, a host environment may introduce additional inhabitants of type `any`
 that are are in neither of the above three leaf type categories.
@@ -696,6 +707,7 @@ This extends the [encodings](https://github.com/WebAssembly/function-references/
 | ------ | --------------- | ---------- | ---- |
 | -0x10  | `funcref`       |            | shorthand, from reftype proposal |
 | -0x11  | `anyref`        |            | shorthand, from reftype proposal |
+| -0x12  | `nullref`       |            | shorthand |
 | -0x13  | `eqref`         |            | shorthand |
 | -0x14  | `(ref null ht)` | `ht : heaptype (s33)` | from funcref proposal |
 | -0x15  | `(ref ht)`      | `ht : heaptype (s33)` | from funcref proposal |
@@ -713,6 +725,7 @@ The opcode for heap types is encoded as an `s33`.
 | i >= 0 | `(type i)`      |            | from funcref proposal |
 | -0x10  | `func`          |            | from funcref proposal |
 | -0x11  | `any`           |            | from funcref proposal |
+| -0x12  | `none`          |            | |
 | -0x13  | `eq`            |            | |
 | -0x16  | `i31`           |            | |
 | -0x18  | `(rtt $t)`      | `$t : typeidx` | |

--- a/proposals/gc/MVP.md
+++ b/proposals/gc/MVP.md
@@ -707,7 +707,6 @@ This extends the [encodings](https://github.com/WebAssembly/function-references/
 | ------ | --------------- | ---------- | ---- |
 | -0x10  | `funcref`       |            | shorthand, from reftype proposal |
 | -0x11  | `anyref`        |            | shorthand, from reftype proposal |
-| -0x12  | `nullref`       |            | shorthand |
 | -0x13  | `eqref`         |            | shorthand |
 | -0x14  | `(ref null ht)` | `ht : heaptype (s33)` | from funcref proposal |
 | -0x15  | `(ref ht)`      | `ht : heaptype (s33)` | from funcref proposal |
@@ -715,6 +714,7 @@ This extends the [encodings](https://github.com/WebAssembly/function-references/
 | -0x18  | `(rtt $t)`      | `$t : typeidx` | shorthand |
 | -0x19  | `dataref`       |            | shorthand |
 | -0x1a  | `arrayref`      |            | shorthand |
+| -0x1b  | `nullref`       |            | shorthand |
 
 #### Heap Types
 
@@ -725,12 +725,12 @@ The opcode for heap types is encoded as an `s33`.
 | i >= 0 | `(type i)`      |            | from funcref proposal |
 | -0x10  | `func`          |            | from funcref proposal |
 | -0x11  | `any`           |            | from funcref proposal |
-| -0x12  | `none`          |            | |
 | -0x13  | `eq`            |            | |
 | -0x16  | `i31`           |            | |
 | -0x18  | `(rtt $t)`      | `$t : typeidx` | |
 | -0x19  | `data`          |            | |
 | -0x1a  | `array`         |            | |
+| -0x1b  | `none`          |            | |
 
 #### Structured Types
 

--- a/test/core/ref_null.wast
+++ b/test/core/ref_null.wast
@@ -1,14 +1,34 @@
 (module
   (type $t (func))
-  (func (export "externref") (result externref) (ref.null extern))
+  (func (export "anyref") (result anyref) (ref.null any))
   (func (export "funcref") (result funcref) (ref.null func))
   (func (export "ref") (result (ref null $t)) (ref.null $t))
 
-  (global externref (ref.null extern))
+  (global anyref (ref.null any))
   (global funcref (ref.null func))
   (global (ref null $t) (ref.null $t))
 )
 
-(assert_return (invoke "externref") (ref.null extern))
+(assert_return (invoke "anyref") (ref.null any))
+(assert_return (invoke "funcref") (ref.null func))
+(assert_return (invoke "ref") (ref.null))
+
+
+(module
+  (type $t (func))
+  (global $null nullref (ref.null none))
+  (func (export "nullref") (result nullref) (global.get $null))
+  (func (export "anyref") (result anyref) (global.get $null))
+  (func (export "funcref") (result funcref) (global.get $null))
+  (func (export "ref") (result (ref null $t)) (global.get $null))
+
+  (global nullref (ref.null none))
+  (global anyref (ref.null none))
+  (global funcref (ref.null none))
+  (global (ref null $t) (ref.null none))
+)
+
+(assert_return (invoke "nullref") (ref.null none))
+(assert_return (invoke "anyref") (ref.null any))
 (assert_return (invoke "funcref") (ref.null func))
 (assert_return (invoke "ref") (ref.null))


### PR DESCRIPTION
Bring back the nullref type.

- In binary, it's a heaptype encoded as -0x12 (previously used for anyref, now unused).
- In text, `nullref` is shorthand for `(ref null none)`, where `none` is the name for the bottom heap type (chosen as opposite to `any`).

No changes needed to the interpreter other than supporting it in binary and text format and allowing it in the validator. The rest of the change is merely renaming and reordering.