### PR TITLE
Refactor casts

### DIFF
--- a/proposals/gc/MVP.md
+++ b/proposals/gc/MVP.md
@@ -600,12 +600,12 @@ Casts work for both abstract and concrete types. In the latter case, they test i
 
 * `ref.test null? <heaptype>` checks whether a reference has a given heap type
   - `ref.test null? ht : [(ref null ht')] -> [i32]`
-    - iff `ht <: ht'`
+    - iff `ht <: tht` and `ht' <: tht` where `tht` is a common super type
   - if `null?` is present, returns 1 for null, otherwise 0
 
 * `ref.cast null? <heaptype>` tries to convert to a given heap type
   - `ref.cast null? ht : [(ref null ht')] -> [(ref null2? ht)]`
-    - iff `ht <: ht'`
+    - iff `ht <: tht` and `ht' <: tht` where `tht` is a common super type
     - and `null? = null2?`
   - traps if reference is not of requested type
   - if `null?` is present, a null operand is passed through, otherwise traps on null
@@ -629,7 +629,7 @@ Casts work for both abstract and concrete types. In the latter case, they test i
   - passes operand along with branch, plus possible extra args
   - if `null?` is present, does not branch on null, otherwise does
 
-Note: Via subsumption to a common supertype, `ref.test` and `ref.cast` actually allow an operand of sibling reference type, even though this cannot possibly succeed. In the case of the branch instruction, this has to be made explicit, though, since the type also occurs in result position. The given typing rules allow this type to also propagate to the result, which avoids the need to compute a least upper bound between the operand type and the target type in the typing algorithm (allowing so is required to maintain subtype substitutability). In practice, it is sufficient to test that both types share the same top heap type.
+Note: Cast instructions do _not_ require the operand's source type to be a supertype of the target type. It can also be a "sibling" in the same hierarchy, i.e., they only need to have a common supertype (in practice, it is sufficient to test that both types share the same top heap type.). Allowing so is necessary to maintain subtype substitutability, i.e., the ability to maintain well-typedness when operands are replaced by subtypes.
 
 Note: The [reference types](https://github.com/WebAssembly/reference-types) and [typed function references](https://github.com/WebAssembly/function-references)already introduce similar `ref.is_null`, `br_on_null`, and `br_on_non_null` instructions. These can now be interpreted as syntactic sugar:
 

--- a/proposals/gc/MVP.md
+++ b/proposals/gc/MVP.md
@@ -598,48 +598,48 @@ In particular, `ref.null` is typed as before, despite the introduction of `none`
 
 Casts work for both abstract and concrete types. In the latter case, they test of the operands RTT is a sub-RTT of the target type.
 
-* `ref.is null? <heaptype>` checks whether a reference is a given heap type
-  - `ref.is null? ht : [(ref null tht)] -> [i32]`
-    - iff `ht <: tht` and `tht` is a top heap type
+* `ref.test null? <heaptype>` checks whether a reference is a given heap type
+  - `ref.test null? ht : [(ref null ht')] -> [i32]`
+    - iff `ht <: tht` and `ht' <: tht` where `tht` is a common super type
   - if `null?` is present, returns 1 for null, otherwise 0
 
-* `ref.as null? <heaptype>` tries to convert to a given heap type
-  - `ref.as null? ht : [(ref null tht)] -> [(ref null2? ht)]`
-    - iff `ht <: tht` and `tht` is a top heap type
+* `ref.cast null? <heaptype>` tries to convert to a given heap type
+  - `ref.cast null? ht : [(ref null ht')] -> [(ref null2? ht)]`
+    - iff `ht <: tht` and `ht' <: tht` where `tht` is a common super type
     - and `null? = null2?`
   - traps if reference is not of requested type
   - if `null?` is present, a null operand is passed through, otherwise traps on null
-  - equivalent to `(block $l (param anyref) (result (ref null? ht)) (br_on null? ht $l) (unreachable))`
+  - equivalent to `(block $l (param anyref) (result (ref null? ht)) (br_on_cast null? ht $l) (unreachable))`
 
-* `br_on <labelidx> null? <heaptype>` branches if a reference is given heap type
-  - `br_on $l null? ht : [t0* (ref null ht')] -> [t0* (ref null2? ht')]`
+* `br_on_cast <labelidx> null? <heaptype>` branches if a reference is given heap type
+  - `br_on_cast $l null? ht : [t0* (ref null ht')] -> [t0* (ref null2? ht')]`
     - iff `$l : [t0* t']`
     - and `(ref null3? ht) <: t'`
-    - and `ht <: tht` and `ht' <: tht` and `tht` is a top heap type
+    - and `ht <: tht` and `ht' <: tht` where `tht` is a common super type
     - and `null? = null3? =/= null2?`
   - passes operand along with branch under target type, plus possible extra args
   - if `null?` is present, branches on null, otherwise does not
 
-* `br_on_non <labelidx> null? <heaptype>` branches if a reference is not a given heap type
-  - `br_on_non $l null? ht : [t0* (ref null ht')] -> [t0* (ref null2? ht)]`
+* `br_on_cast_fail <labelidx> null? <heaptype>` branches if a reference is not a given heap type
+  - `br_on_cast_fail $l null? ht : [t0* (ref null ht')] -> [t0* (ref null2? ht)]`
     - iff `$l : [t0* t']`
     - and `(ref null3? ht) <: t'`
-    - and `ht <: tht` and `ht' <: tht` and `tht` is a top heap type
+    - and `ht <: tht` and `ht' <: tht` where `tht` is a common super type
     - and `null? = null2? =/= null3?`
   - passes operand along with branch, plus possible extra args
   - if `null?` is present, does not branch on null, otherwise does
 
-Note: The `br_on`/`br_on_non` instructions allow an operand of sibling reference type, even though this cannot possibly succeed. That's because subtyping allows to forget that information, so by the subtype substitutibility property, it would be accepted in any case. The given typing rules merely allow this type to also propagate to the result, which avoids the need to compute a least upper bound between the operand type and the target type in the typing algorithm.
+Note: Cast instructions allow an operand of sibling reference type, even though this cannot possibly succeed. That's because subtyping allows to forget type information and go to a common supertype, so by the subtype substitutibility property, it would be accepted in any case. The given typing rules merely allow this type to also propagate to the result, which avoids the need to compute a least upper bound between the operand type and the target type in the typing algorithm. In practice, it is sufficient to test that both types share the same top heap type.
 
 Note: The [reference types](https://github.com/WebAssembly/reference-types) and [typed function references](https://github.com/WebAssembly/function-references)already introduce similar `ref.is_null`, `br_on_null`, and `br_on_non_null` instructions. These can now be interpreted as syntactic sugar:
 
-* `ref.is_null` is equivalent to `ref.is null ht`, where `tht` is the suitable bottom type (`none`, `nofunc`, or `noextern`)
+* `ref.is_null` is equivalent to `ref.test null ht`, where `tht` is the suitable bottom type (`none`, `nofunc`, or `noextern`)
 
-* `br_on_null` is equivalent to `br_on null ht`, where `tht` is the suitable bottom type
+* `br_on_null` is equivalent to `br_on_cast null ht`, where `tht` is the suitable bottom type
 
-* `br_on_non_null` is equivalent to `br_on_non null ht`, where `tht` is the suitable bottom type
+* `br_on_non_null` is equivalent to `br_on_cast_fail null ht`, where `tht` is the suitable bottom type
 
-* finally, `ref.as_non_null` is equivalent to `ref.as ht`, where `ht` is the heap type of the operand
+* finally, `ref.as_non_null` is equivalent to `ref.cast ht`, where `ht` is the heap type of the operand
 
 
 #### Constant Expressions
@@ -757,14 +757,14 @@ The opcode for heap types is encoded as an `s33`.
 | 0xfb20 | `i31.new` |  |
 | 0xfb21 | `i31.get_s` |  |
 | 0xfb22 | `i31.get_u` |  |
-| 0xfb40 | `ref.is ht` | `ht : heaptype` |
-| 0xfb41 | `ref.as ht` | `ht : heaptype` |
-| 0xfb42 | `br_on $l ht` | `$l : labelidx`, `ht : heaptype` |
-| 0xfb43 | `br_on_non $l ht` | `$l : labelidx`, `ht : heaptype` |
-| 0xfb40 | `ref.is null ht` | `ht : heaptype` |
-| 0xfb41 | `ref.as null ht` | `ht : heaptype` |
-| 0xfb42 | `br_on $l null ht` | `$l : labelidx`, `ht : heaptype` |
-| 0xfb43 | `br_on_non $l null ht` | `$l : labelidx`, `ht : heaptype` |
+| 0xfb40 | `ref.test ht` | `ht : heaptype` |
+| 0xfb41 | `ref.cast ht` | `ht : heaptype` |
+| 0xfb42 | `br_on_cast $l ht` | `$l : labelidx`, `ht : heaptype` |
+| 0xfb43 | `br_on_cast_fail $l ht` | `$l : labelidx`, `ht : heaptype` |
+| 0xfb40 | `ref.test null ht` | `ht : heaptype` |
+| 0xfb41 | `ref.cast null ht` | `ht : heaptype` |
+| 0xfb42 | `br_on_cast $l null ht` | `$l : labelidx`, `ht : heaptype` |
+| 0xfb43 | `br_on_cast_fail $l null ht` | `$l : labelidx`, `ht : heaptype` |
 | 0xfb70 | `extern.internalize` | |
 | 0xfb71 | `extern.externalize` | |
 

--- a/proposals/gc/MVP.md
+++ b/proposals/gc/MVP.md
@@ -641,6 +641,8 @@ Note: The [reference types](https://github.com/WebAssembly/reference-types) and 
 
 * finally, `ref.as_non_null` is equivalent to `ref.cast ht`, where `ht` is the heap type of the operand
 
+TODO: Should we remove the latter 3 from the typed function references proposal?
+
 
 #### Constant Expressions
 

--- a/proposals/gc/MVP.md
+++ b/proposals/gc/MVP.md
@@ -629,9 +629,17 @@ Casts work for both abstract and concrete types. In the latter case, they test o
   - passes operand along with branch, plus possible extra args
   - if `null?` is present, does not branch on null, otherwise does
 
-Note: The [reference types](https://github.com/WebAssembly/reference-types) and [typed function references](https://github.com/WebAssembly/function-references)already introduce similar `ref.is_null`, `br_on_null`, and `br_on_non_null` instructions.
-
 Note: The `br_on`/`br_on_non` instructions allow an operand of sibling reference type, even though this cannot possibly succeed. That's because subtyping allows to forget that information, so by the subtype substitutibility property, it would be accepted in any case. The given typing rules merely allow this type to also propagate to the result, which avoids the need to compute a least upper bound between the operand type and the target type in the typing algorithm.
+
+Note: The [reference types](https://github.com/WebAssembly/reference-types) and [typed function references](https://github.com/WebAssembly/function-references)already introduce similar `ref.is_null`, `br_on_null`, and `br_on_non_null` instructions. These can now be interpreted as syntactic sugar:
+
+* `ref.is_null` is equivalent to `ref.is null ht`, where `tht` is the suitable bottom type (`none`, `nofunc`, or `noextern`)
+
+* `br_on_null` is equivalent to `br_on null ht`, where `tht` is the suitable bottom type
+
+* `br_on_non_null` is equivalent to `br_on_non null ht`, where `tht` is the suitable bottom type
+
+* finally, `ref.as_non_null` is equivalent to `ref.as ht`, where `ht` is the heap type of the operand
 
 
 #### Constant Expressions

--- a/proposals/gc/MVP.md
+++ b/proposals/gc/MVP.md
@@ -623,7 +623,7 @@ Casts work for both abstract and concrete types. In the latter case, they test i
 * `br_on_cast_fail <labelidx> null? <heaptype>` branches if a reference does not have a given heap type
   - `br_on_cast_fail $l null? ht : [t0* (ref null ht')] -> [t0* (ref null2? ht)]`
     - iff `$l : [t0* t']`
-    - and `(ref null3? ht) <: t'`
+    - and `(ref null3? ht') <: t'`
     - and `ht <: tht` and `ht' <: tht` where `tht` is a common super type
     - and `null? = null2? =/= null3?`
   - passes operand along with branch, plus possible extra args

--- a/proposals/gc/MVP.md
+++ b/proposals/gc/MVP.md
@@ -635,9 +635,9 @@ Note: The [reference types](https://github.com/WebAssembly/reference-types) and 
 
 * `ref.is_null` is equivalent to `ref.test null ht`, where `ht` is the suitable bottom type (`none`, `nofunc`, or `noextern`)
 
-* `br_on_null` is equivalent to `br_on_cast null ht`, where `ht` is the suitable bottom type
+* `br_on_null` is equivalent to `br_on_cast null ht`, where `ht` is the suitable bottom type, except that it does not forward the null value
 
-* `br_on_non_null` is equivalent to `br_on_cast_fail null ht`, where `ht` is the suitable bottom type
+* `br_on_non_null` is equivalent to `(br_on_cast_fail null ht) (drop)`, where `ht` is the suitable bottom type
 
 * finally, `ref.as_non_null` is equivalent to `ref.cast ht`, where `ht` is the heap type of the operand
 


### PR DESCRIPTION
Addresses #274.

This PR modifies the MVP doc to replace the existing classification and cast instructions with casts that can target any reference type:
```
ref.test null? <heaptype>
ref.cast null? <heaptype>
br_on_cast $l null? <heaptype>
br_on_cast_fail $l null? <heaptype>
```
The typing rules for these casts become somewhat complex, in order (1) to make sure that source and target type are in the same hierarchy, and (2) to handle the propagation and negation of the optional `null` attributes correctly.

Furthermore, the PR repurposes the `dataref` type as `structref`. The main purpose of `data` was to denote the required source type for concrete casts. Since that requirement is gone, so is the purpose. For the remaining use cases, `struct` is typically more precise. That also avoids some of the concerns that came up earlier regarding the forward compatibility of exhaustive type inspections on such a "middle" type.

Note: I gave up on the idea of having two separate cast instructions for abstract vs concrete types, since that just seemed a bit silly at this point – I convinced myself that the distinction can be reintroduced later in a warty way if needs be. I don't expect that anybody will object to that. I also included top types and `eqref` as allowable cast targets, although I still think this actually is a directional mistake and introduces both a legacy cost and creates the wrong expectations moving forward. Mainly I've just grown tired of the discussion.