### PR TITLE
Allow mutable fields in struct.new[_default]

### DIFF
--- a/proposals/gc/MVP.md
+++ b/proposals/gc/MVP.md
@@ -487,13 +487,13 @@ In particular, `ref.null` is typed as before, despite the introduction of `none`
 
 * `struct.new_canon <typeidx>` allocates a structure with canonical [RTT](#values) and initialises its fields with given values
   - `struct.new_canon $t : [t'*] -> [(ref $t)]`
-    - iff `expand($t) = struct (mut t'')*`
+    - iff `expand($t) = struct (mut? t'')*`
     - and `(t' = unpacked(t''))*`
   - this is a *constant instruction*
 
 * `struct.new_canon_default <typeidx>` allocates a structure of type `$t` with canonical [RTT](#values) and initialises its fields with default values
   - `struct.new_canon_default $t : [] -> [(ref $t)]`
-    - iff `expand($t) = struct (mut t')*`
+    - iff `expand($t) = struct (mut? t')*`
     - and all `t'*` are defaultable
   - this is a *constant instruction*
 


### PR DESCRIPTION
The mutability or immutability of fields should not matter when creating a struct, unless I am missing something? That is, it's always fine to create a struct (with or without default values) even if the fields are immutable. Immutability just affects changes later, using `struct.set`:

```wat
(type $T (struct_subtype (field i32) data)

(struct.new_default $T) ;; this is fine, the field will contain 0, and never be modified later.
(struct.set $T 0 ..) ;; this is not fine, the field is immutable.
```

This was noticed on a [Dart benchmark](https://github.com/dart-lang/sdk/issues/50268). V8 atm will error on immutable fields, following the old text here, and Binaryen will turn fields immutable when it sees no sets to them.

edit: I was confused about the `canon` names, sorry about that. PR has been updated.