### PR TITLE
Add `final` attribute

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
       - run: pip install bikeshed && bikeshed update
       - run: pip install six
       - run: sudo apt-get update -y && sudo apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
-      - run: pip install sphinx==4.0.0
+      - run: pip install sphinx==5.1.0
       - run: cd document/core && make all
       - uses: actions/upload-artifact@v2
         with:

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -256,8 +256,12 @@ let sub_type s =
   | Some i when i = -0x30 land 0x7f ->
     skip 1 s;
     let xs = vec (var_type u32) s in
-    SubT (xs, str_type s)
-  | _ -> SubT ([], str_type s)
+    SubT (NoFinal, xs, str_type s)
+  | Some i when i = -0x32 land 0x7f ->
+    skip 1 s;
+    let xs = vec (var_type u32) s in
+    SubT (Final, xs, str_type s)
+  | _ -> SubT (Final, [], str_type s)
 
 let def_type s =
   match peek s with

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -173,8 +173,9 @@ struct
     | DefFuncT ft -> s7 (-0x20); func_type ft
 
   let sub_type = function
-    | SubT ([], st) -> str_type st
-    | SubT (xs, st) -> s7 (-0x30); vec (var_type u32) xs; str_type st
+    | SubT (Final, [], st) -> str_type st
+    | SubT (Final, xs, st) -> s7 (-0x32); vec (var_type u32) xs; str_type st
+    | SubT (NoFinal, xs, st) -> s7 (-0x30); vec (var_type u32) xs; str_type st
 
   let def_type = function
     | RecT [st] -> sub_type st

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -244,7 +244,7 @@ let rec step (c : config) : config =
       | CallIndirect (x, y), Num (I32 i) :: vs ->
         let f = func_ref c.frame.inst x i e.at in
         if
-          Match.eq_var_type [] (DynX (type_ c.frame.inst y)) (DynX (Func.type_inst_of f))
+          Match.match_var_type [] (DynX (Func.type_inst_of f)) (DynX (type_ c.frame.inst y))
         then
           vs, [Invoke f @@ e.at]
         else

--- a/interpreter/host/spectest.ml
+++ b/interpreter/host/spectest.ml
@@ -29,7 +29,7 @@ let memory =
 
 let func f ft =
   let x = Types.alloc_uninit () in
-  Types.init x (CtxT ([(DynX x, SubT ([], DefFuncT ft))], 0l));
+  Types.init x (CtxT ([(DynX x, SubT (Final, [], DefFuncT ft))], 0l));
   ExternFunc (Func.alloc_host x (f ft))
 
 let print_value v =

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -270,7 +270,7 @@ let value v =
   | Ref _ -> assert false
 
 let invoke ft vs at =
-  let dt = RecT [SubT ([], DefFuncT ft)] in
+  let dt = RecT [SubT (Final, [], DefFuncT ft)] in
   [dt @@ at], FuncImport (subject_type_idx @@ at) @@ at,
   List.concat (List.map value vs) @ [Call (subject_idx @@ at) @@ at]
 
@@ -380,7 +380,8 @@ let assert_return ress ts at =
 let i32 = NumT I32T
 let anyref = RefT (Null, AnyHT)
 let eqref = RefT (Null, EqHT)
-let func_def_type ts1 ts2 at = RecT [SubT ([], DefFuncT (FuncT (ts1, ts2)))] @@ at
+let func_def_type ts1 ts2 at =
+  RecT [SubT (Final, [], DefFuncT (FuncT (ts1, ts2)))] @@ at
 
 let wrap item_name wrap_action wrap_assertion at =
   let itypes, idesc, action = wrap_action at in

--- a/interpreter/syntax/free.ml
+++ b/interpreter/syntax/free.ml
@@ -107,7 +107,7 @@ let str_type = function
   | DefFuncT ft -> func_type ft
 
 let sub_type = function
-  | SubT (xs, st) -> list var_type xs ++ str_type st
+  | SubT (_fin, xs, st) -> list var_type xs ++ str_type st
 
 let def_type = function
   | RecT sts -> list sub_type sts

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -86,6 +86,10 @@ let null = function
   | NoNull -> ""
   | Null -> "null "
 
+let final = function
+  | NoFinal -> ""
+  | Final -> " final"
+
 let ref_type_raw (nul, t) =
   Atom (null nul ^ heap_type t)
 
@@ -110,9 +114,10 @@ let str_type st =
   | DefFuncT ft -> func_type ft
 
 let sub_type = function
-  | SubT ([], st) -> str_type st
-  | SubT (xs, st) ->
-    Node (String.concat " " ("sub" :: List.map var_type xs), [str_type st])
+  | SubT (Final, [], st) -> str_type st
+  | SubT (fin, xs, st) ->
+    Node (String.concat " "
+      (("sub" ^ final fin ):: List.map var_type xs), [str_type st])
 
 let def_type i j st =
   Node ("type $" ^ nat (i + j), [sub_type st])

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -175,6 +175,7 @@ rule token = parse
       | "field" -> FIELD
       | "mut" -> MUT
       | "sub" -> SUB
+      | "final" -> FINAL
       | "rec" -> REC
 
       | "nop" -> NOP

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -212,7 +212,7 @@ let anon_fields (c : context) n at = bind "field" c.fields n at
 
 
 let inline_func_type (c : context) ft at =
-  let st = SubT ([], DefFuncT ft) in
+  let st = SubT (Final, [], DefFuncT ft) in
   match
     Lib.List.index_where (function
       | CtxT ([(_, st')], 0l) -> st = st'
@@ -248,7 +248,7 @@ let inline_func_type_explicit (c : context) x ft at =
 %token ANYREF NULLREF EQREF I31REF STRUCTREF ARRAYREF
 %token FUNCREF NULLFUNCREF EXTERNREF NULLEXTERNREF
 %token ANY NONE EQ I31 REF NOFUNC EXTERN NOEXTERN NULL
-%token MUT FIELD STRUCT ARRAY SUB REC
+%token MUT FIELD STRUCT ARRAY SUB FINAL REC
 %token UNREACHABLE NOP DROP SELECT
 %token BLOCK END IF THEN ELSE LOOP
 %token BR BR_IF BR_TABLE BR_ON_NULL BR_ON_NON_NULL BR_ON_CAST BR_ON_CAST_FAIL
@@ -439,9 +439,11 @@ str_type :
   | LPAR FUNC func_type RPAR { fun c -> DefFuncT ($3 c) }
 
 sub_type :
-  | str_type { fun c -> SubT ([], $1 c) }
+  | str_type { fun c -> SubT (Final, [], $1 c) }
   | LPAR SUB var_list str_type RPAR
-    { fun c -> SubT (List.map (fun x -> StatX x.it) ($3 c type_), $4 c) }
+    { fun c -> SubT (NoFinal, List.map (fun x -> StatX x.it) ($3 c type_), $4 c) }
+  | LPAR SUB FINAL var_list str_type RPAR
+    { fun c -> SubT (Final, List.map (fun x -> StatX x.it) ($4 c type_), $5 c) }
 
 table_type :
   | limits ref_type { fun c -> TableT ($1, $2 c) }

--- a/interpreter/valid/match.ml
+++ b/interpreter/valid/match.ml
@@ -127,8 +127,8 @@ and eq_str_type c dt1 dt2 =
   | DefFuncT ft1, DefFuncT ft2 -> eq_func_type c ft1 ft2
   | _, _ -> false
 
-and eq_sub_type c (SubT (xs1, st1)) (SubT (xs2, st2)) =
-  eq_list eq_var_type c xs1 xs2 && eq_str_type c st1 st2
+and eq_sub_type c (SubT (fin1, xs1, st1)) (SubT (fin2, xs2, st2)) =
+  fin1 = fin2 && eq_list eq_var_type c xs1 xs2 && eq_str_type c st1 st2
 
 and eq_def_type c (RecT sts1) (RecT sts2) =
   eq_list eq_sub_type c sts1 sts2
@@ -261,9 +261,8 @@ and match_str_type c dt1 dt2 =
 and match_var_type c x1 x2 =
   eq_var x1 x2 ||
   not (is_rec_var x1 || is_rec_var x2) && eq_ctx_type c (lookup c x1) (lookup c x2) ||
-  let SubT (xs, _) = unroll_ctx_type (lookup c x1) in
+  let SubT (_fin, xs, _st) = unroll_ctx_type (lookup c x1) in
   List.exists (fun x -> match_var_type c x x2) xs
-
 
 let match_table_type c (TableT (lim1, t1)) (TableT (lim2, t2)) =
   match_limits c lim1 lim2 && eq_ref_type c t1 t2

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -170,13 +170,16 @@ let check_str_type (c : context) (st : str_type) at =
   | DefFuncT ft -> check_func_type c ft at
 
 let check_sub_type (c : context) (st : sub_type) x at =
-  let SubT (xs, st) = st in
+  let SubT (fin, xs, st) = st in
   check_str_type c st at;
   List.iter (fun xi ->
     let xi = as_stat_var xi in
     require (xi < x) at
       ("forward use of type " ^ I32.to_string_u xi ^  " in sub type definition");
-    require (match_str_type c.types st (expand_ctx_type (type_ c (xi @@ at)))) at
+    let SubT (fini, _, sti) = unroll_ctx_type (type_ c (xi @@ at)) in
+    require (fini = NoFinal) at
+      ("sub type " ^ I32.to_string_u x ^ " has final super type " ^ I32.to_string_u xi);
+    require (match_str_type c.types st sti) at
       ("sub type " ^ I32.to_string_u x ^ " does not match super type " ^ I32.to_string_u xi)
   ) xs
 

--- a/proposals/gc/MVP.md
+++ b/proposals/gc/MVP.md
@@ -453,7 +453,7 @@ Note: This assumes that there is at most one supertype. For hierarchies with mul
 
 Example: Consider three types and corresponding RTTs:
 ```
-(type $A (struct))
+(type $A (sub (struct)))
 (type $B (sub $A (struct (field i32))))
 (type $C (sub $B (struct (field i32 i64))))
 ```

--- a/test/core/gc/br_on_cast.wast
+++ b/test/core/gc/br_on_cast.wast
@@ -86,7 +86,7 @@
 ;; Concrete Types
 
 (module
-  (type $t0 (struct))
+  (type $t0 (sub (struct)))
   (type $t1 (sub $t0 (struct (field i32))))
   (type $t1' (sub $t0 (struct (field i32))))
   (type $t2 (sub $t1 (struct (field i32 i32))))

--- a/test/core/gc/br_on_cast_fail.wast
+++ b/test/core/gc/br_on_cast_fail.wast
@@ -86,7 +86,7 @@
 ;; Concrete Types
 
 (module
-  (type $t0 (struct))
+  (type $t0 (sub (struct)))
   (type $t1 (sub $t0 (struct (field i32))))
   (type $t1' (sub $t0 (struct (field i32))))
   (type $t2 (sub $t1 (struct (field i32 i32))))

--- a/test/core/gc/ref_cast.wast
+++ b/test/core/gc/ref_cast.wast
@@ -97,7 +97,7 @@
 ;; Concrete Types
 
 (module
-  (type $t0 (struct))
+  (type $t0 (sub (struct)))
   (type $t1 (sub $t0 (struct (field i32))))
   (type $t1' (sub $t0 (struct (field i32))))
   (type $t2 (sub $t1 (struct (field i32 i32))))

--- a/test/core/gc/ref_eq.wast
+++ b/test/core/gc/ref_eq.wast
@@ -1,6 +1,6 @@
 (module
-  (type $st (struct))
-  (type $st' (struct (field i32)))
+  (type $st (sub (struct)))
+  (type $st' (sub (struct (field i32))))
   (type $at (array i8))
   (type $st-sub1 (sub $st (struct)))
   (type $st-sub2 (sub $st (struct)))

--- a/test/core/gc/ref_test.wast
+++ b/test/core/gc/ref_test.wast
@@ -180,7 +180,7 @@
 ;; Concrete Types
 
 (module
-  (type $t0 (struct))
+  (type $t0 (sub (struct)))
   (type $t1 (sub $t0 (struct (field i32))))
   (type $t1' (sub $t0 (struct (field i32))))
   (type $t2 (sub $t1 (struct (field i32 i32))))

--- a/test/core/gc/type-subtyping.wast
+++ b/test/core/gc/type-subtyping.wast
@@ -1,19 +1,19 @@
 ;; Definitions
 
 (module
-  (type $e0 (array i32))
+  (type $e0 (sub (array i32)))
   (type $e1 (sub $e0 (array i32)))
 
-  (type $e2 (array anyref))
+  (type $e2 (sub (array anyref)))
   (type $e3 (sub (array (ref null $e0))))
   (type $e4 (sub (array (ref $e1))))
 
-  (type $m1 (array (mut i32)))
+  (type $m1 (sub (array (mut i32))))
   (type $m2 (sub $m1 (array (mut i32))))
 )
 
 (module
-  (type $e0 (struct))
+  (type $e0 (sub (struct)))
   (type $e1 (sub $e0 (struct)))
   (type $e2 (sub $e1 (struct (field i32))))
   (type $e3 (sub $e2 (struct (field i32 (ref null $e0)))))
@@ -22,10 +22,10 @@
 )
 
 (module
-  (type $s (struct))
+  (type $s (sub (struct)))
   (type $s' (sub $s (struct)))
 
-  (type $f1 (func (param (ref $s')) (result anyref)))
+  (type $f1 (sub (func (param (ref $s')) (result anyref))))
   (type $f2 (sub $f1 (func (param (ref $s)) (result (ref any)))))
   (type $f3 (sub $f2 (func (param (ref null $s)) (result (ref $s)))))
   (type $f4 (sub $f3 (func (param (ref null struct)) (result (ref $s')))))
@@ -35,14 +35,14 @@
 ;; Recursive definitions
 
 (module
-  (type $t (struct (field anyref)))
+  (type $t (sub (struct (field anyref))))
   (rec (type $r (sub $t (struct (field (ref $r))))))
   (type $t' (sub $r (struct (field (ref $r) i32))))
 )
 
 (module
   (rec
-    (type $r1 (struct (field i32 (ref $r1))))
+    (type $r1 (sub (struct (field i32 (ref $r1)))))
   )
   (rec
     (type $r2 (sub $r1 (struct (field i32 (ref $r3)))))
@@ -52,8 +52,8 @@
 
 (module
   (rec
-    (type $a1 (struct (field i32 (ref $a2))))
-    (type $a2 (struct (field i64 (ref $a1))))
+    (type $a1 (sub (struct (field i32 (ref $a2)))))
+    (type $a2 (sub (struct (field i64 (ref $a1)))))
   )
   (rec
     (type $b1 (sub $a2 (struct (field i64 (ref $a1) i32))))
@@ -67,7 +67,7 @@
 
 (module
   (rec
-    (type $t1 (func (param i32 (ref $t3))))
+    (type $t1 (sub (func (param i32 (ref $t3)))))
     (type $t2 (sub $t1 (func (param i32 (ref $t2)))))
     (type $t3 (sub $t2 (func (param i32 (ref $t1)))))
   )
@@ -88,8 +88,8 @@
 
 (module
   (rec
-    (type $t1 (func (result i32 (ref $u1))))
-    (type $u1 (func (result f32 (ref $t1))))
+    (type $t1 (sub (func (result i32 (ref $u1)))))
+    (type $u1 (sub (func (result f32 (ref $t1)))))
   )
 
   (rec
@@ -116,36 +116,108 @@
 ;; Runtime types
 
 (module
-  (rec (type $t1 (func (result (ref null $t1)))))
+  (rec (type $t0 (sub (func (result (ref null func))))))
+  (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
   (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
 
+  (func $f0 (type $t0) (ref.null func))
   (func $f1 (type $t1) (ref.null $t1))
   (func $f2 (type $t2) (ref.null $t2))
-  (table funcref (elem $f1 $f2))
+  (table funcref (elem $f0 $f1 $f2))
 
   (func (export "run")
-    (block (result (ref null $t1)) (call_indirect (type $t1) (i32.const 0)))
-    (block (result (ref null $t2)) (call_indirect (type $t2) (i32.const 1)))
-    (block (result (ref null $t1)) (ref.cast $t1 (table.get (i32.const 0))))
+    (block (result (ref null func)) (call_indirect (type $t0) (i32.const 0)))
+    (block (result (ref null func)) (call_indirect (type $t0) (i32.const 1)))
+    (block (result (ref null func)) (call_indirect (type $t0) (i32.const 2)))
+    (block (result (ref null $t1)) (call_indirect (type $t1) (i32.const 1)))
+    (block (result (ref null $t1)) (call_indirect (type $t1) (i32.const 2)))
+    (block (result (ref null $t2)) (call_indirect (type $t2) (i32.const 2)))
+
+    (block (result (ref null $t0)) (ref.cast $t0 (table.get (i32.const 0))))
+    (block (result (ref null $t0)) (ref.cast $t0 (table.get (i32.const 1))))
+    (block (result (ref null $t0)) (ref.cast $t0 (table.get (i32.const 2))))
     (block (result (ref null $t1)) (ref.cast $t1 (table.get (i32.const 1))))
-    (block (result (ref null $t2)) (ref.cast $t2 (table.get (i32.const 1))))
+    (block (result (ref null $t1)) (ref.cast $t1 (table.get (i32.const 2))))
+    (block (result (ref null $t2)) (ref.cast $t2 (table.get (i32.const 2))))
     (br 0)
   )
 
-  (func (export "fail")
-    (block (result (ref null $t1)) (call_indirect (type $t1) (i32.const 1)))
+  (func (export "fail1")
+    (block (result (ref null $t1)) (call_indirect (type $t1) (i32.const 0)))
+    (br 0)
+  )
+  (func (export "fail2")
+    (block (result (ref null $t1)) (call_indirect (type $t2) (i32.const 0)))
+    (br 0)
+  )
+  (func (export "fail3")
+    (block (result (ref null $t1)) (call_indirect (type $t2) (i32.const 1)))
+    (br 0)
+  )
+
+  (func (export "fail4")
+    (ref.cast $t1 (table.get (i32.const 0)))
+    (br 0)
+  )
+  (func (export "fail5")
+    (ref.cast $t2 (table.get (i32.const 0)))
+    (br 0)
+  )
+  (func (export "fail6")
+    (ref.cast $t2 (table.get (i32.const 1)))
     (br 0)
   )
 )
 (assert_return (invoke "run"))
-(assert_trap (invoke "fail") "indirect call")
+(assert_trap (invoke "fail1") "indirect call")
+(assert_trap (invoke "fail2") "indirect call")
+(assert_trap (invoke "fail3") "indirect call")
+(assert_trap (invoke "fail4") "cast")
+(assert_trap (invoke "fail5") "cast")
+(assert_trap (invoke "fail6") "cast")
+
+
+;; Finality violation
+
+(assert_invalid
+  (module
+    (type $t (func))
+    (type $s (sub $t (func)))
+  )
+  "sub type"
+)
+
+(assert_invalid
+  (module
+    (type $t (struct))
+    (type $s (sub $t (struct)))
+  )
+  "sub type"
+)
+
+(assert_invalid
+  (module
+    (type $t (sub final (func)))
+    (type $s (sub $t (func)))
+  )
+  "sub type"
+)
+
+(assert_invalid
+  (module
+    (type $t (sub (func)))
+    (type $s (sub final $t (func)))
+    (type $u (sub $s (func)))
+  )
+  "sub type"
+)
 
 
 ;; Invalid subtyping definitions
 
 (assert_invalid
   (module
-    (type $a0 (array i32))
+    (type $a0 (sub (array i32)))
     (type $s0 (sub $a0 (struct)))
   )
   "sub type"
@@ -153,7 +225,7 @@
 
 (assert_invalid 
   (module
-    (type $f0 (func (param i32) (result i32)))
+    (type $f0 (sub (func (param i32) (result i32))))
     (type $s0 (sub $f0 (struct)))
   )
   "sub type"
@@ -161,7 +233,7 @@
 
 (assert_invalid
   (module
-    (type $s0 (struct))
+    (type $s0 (sub (struct)))
     (type $a0 (sub $s0 (array i32)))
   )
   "sub type"
@@ -169,7 +241,7 @@
 
 (assert_invalid
   (module
-    (type $f0 (func (param i32) (result i32)))
+    (type $f0 (sub (func (param i32) (result i32))))
     (type $a0 (sub $f0 (array i32)))
   )
   "sub type"
@@ -177,7 +249,7 @@
 
 (assert_invalid 
   (module
-    (type $s0 (struct))
+    (type $s0 (sub (struct)))
     (type $f0 (sub $s0 (func (param i32) (result i32))))
   )
   "sub type"
@@ -185,7 +257,7 @@
 
 (assert_invalid 
   (module
-    (type $a0 (array i32))
+    (type $a0 (sub (array i32)))
     (type $f0 (sub $a0 (func (param i32) (result i32))))
   )
   "sub type"
@@ -193,7 +265,7 @@
 
 (assert_invalid
   (module
-    (type $a0 (array i32))
+    (type $a0 (sub (array i32)))
     (type $a1 (sub $a0 (array i64)))
   )
   "sub type"
@@ -201,7 +273,7 @@
 
 (assert_invalid
   (module
-    (type $s0 (struct (field i32)))
+    (type $s0 (sub (struct (field i32))))
     (type $s1 (sub $s0 (struct (field i64))))
   )
   "sub type"
@@ -209,7 +281,7 @@
 
 (assert_invalid
   (module
-    (type $f0 (func))
+    (type $f0 (sub (func)))
     (type $f1 (sub $f0 (func (param i32))))
   )
   "sub type"

--- a/test/core/gc/type-subtyping.wast
+++ b/test/core/gc/type-subtyping.wast
@@ -177,6 +177,65 @@
 (assert_trap (invoke "fail6") "cast")
 
 
+
+;; Linking
+
+(module
+  (rec (type $t0 (sub (func (result (ref null func))))))
+  (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
+  (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+
+  (func (export "f0") (type $t0) (ref.null func))
+  (func (export "f1") (type $t1) (ref.null $t1))
+  (func (export "f2") (type $t2) (ref.null $t2))
+)
+(register "M")
+
+(module
+  (rec (type $t0 (sub (func (result (ref null func))))))
+  (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
+  (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+
+  (func (import "M" "f0") (type $t0))
+  (func (import "M" "f1") (type $t0))
+  (func (import "M" "f1") (type $t1))
+  (func (import "M" "f2") (type $t0))
+  (func (import "M" "f2") (type $t1))
+  (func (import "M" "f2") (type $t2))
+)
+
+(assert_unlinkable
+  (module
+    (rec (type $t0 (sub (func (result (ref null func))))))
+    (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
+    (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+    (func (import "M" "f0") (type $t1))
+  )
+  "incompatible import type"
+)
+
+(assert_unlinkable
+  (module
+    (rec (type $t0 (sub (func (result (ref null func))))))
+    (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
+    (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+    (func (import "M" "f0") (type $t2))
+  )
+  "incompatible import type"
+)
+
+(assert_unlinkable
+  (module
+    (rec (type $t0 (sub (func (result (ref null func))))))
+    (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
+    (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+    (func (import "M" "f1") (type $t2))
+  )
+  "incompatible import type"
+)
+
+
+
 ;; Finality violation
 
 (assert_invalid

--- a/test/core/gc/type-subtyping.wast
+++ b/test/core/gc/type-subtyping.wast
@@ -116,7 +116,7 @@
 ;; Runtime types
 
 (module
-  (rec (type $t0 (sub (func (result (ref null func))))))
+  (type $t0 (sub (func (result (ref null func)))))
   (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
   (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
 
@@ -176,12 +176,41 @@
 (assert_trap (invoke "fail5") "cast")
 (assert_trap (invoke "fail6") "cast")
 
+(module
+  (type $t1 (sub (func)))
+  (type $t2 (sub final (func)))
+
+  (func $f1 (type $t1))
+  (func $f2 (type $t2))
+  (table funcref (elem $f1 $f2))
+
+  (func (export "fail1")
+    (block (call_indirect (type $t1) (i32.const 1)))
+  )
+  (func (export "fail2")
+    (block (call_indirect (type $t2) (i32.const 0)))
+  )
+
+  (func (export "fail3")
+    (ref.cast $t1 (table.get (i32.const 1)))
+    (drop)
+  )
+  (func (export "fail4")
+    (ref.cast $t2 (table.get (i32.const 0)))
+    (drop)
+  )
+)
+(assert_trap (invoke "fail1") "indirect call")
+(assert_trap (invoke "fail2") "indirect call")
+(assert_trap (invoke "fail3") "cast")
+(assert_trap (invoke "fail4") "cast")
+
 
 
 ;; Linking
 
 (module
-  (rec (type $t0 (sub (func (result (ref null func))))))
+  (type $t0 (sub (func (result (ref null func)))))
   (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
   (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
 
@@ -192,7 +221,7 @@
 (register "M")
 
 (module
-  (rec (type $t0 (sub (func (result (ref null func))))))
+  (type $t0 (sub (func (result (ref null func)))))
   (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
   (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
 
@@ -206,7 +235,7 @@
 
 (assert_unlinkable
   (module
-    (rec (type $t0 (sub (func (result (ref null func))))))
+    (type $t0 (sub (func (result (ref null func)))))
     (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
     (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
     (func (import "M" "f0") (type $t1))
@@ -216,7 +245,7 @@
 
 (assert_unlinkable
   (module
-    (rec (type $t0 (sub (func (result (ref null func))))))
+    (type $t0 (sub (func (result (ref null func)))))
     (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
     (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
     (func (import "M" "f0") (type $t2))
@@ -226,10 +255,35 @@
 
 (assert_unlinkable
   (module
-    (rec (type $t0 (sub (func (result (ref null func))))))
+    (type $t0 (sub (func (result (ref null func)))))
     (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
     (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
     (func (import "M" "f1") (type $t2))
+  )
+  "incompatible import type"
+)
+
+(module
+  (type $t1 (sub (func)))
+  (type $t2 (sub final (func)))
+  (func (export "f1") (type $t1))
+  (func (export "f2") (type $t2))
+)
+(register "M2")
+
+(assert_unlinkable
+  (module
+    (type $t1 (sub (func)))
+    (type $t2 (sub final (func)))
+    (func (import "M2" "f1") (type $t2))
+  )
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module
+    (type $t1 (sub (func)))
+    (type $t2 (sub final (func)))
+    (func (import "M2" "f2") (type $t1))
   )
   "incompatible import type"
 )
@@ -270,6 +324,7 @@
   )
   "sub type"
 )
+
 
 
 ;; Invalid subtyping definitions


### PR DESCRIPTION
This adds a spec of the final attribute for experimentation:

* In the abstract syntax, it is possible to write `sub $t* ...` or `sub final $t* ...`.
* In the binary format, `sub final` is encoded as `-0x32`, with the same format as `sub`.
* When validating a `sub` definition, none of the supertypes may be final.
* The non-sub shorthands (and therefor existing function types) are reinterpreted to `final`.

Due to the latter, a subtypable struct or array must now be written explicitly, with an empty list of supertypes:
```
(type (struct))  ;; final, no supertypes (shorthand)
(type (sub final (struct)))  ;; same in expanded form
(type (sub (struct)))  ;; non-final, no supertypes
(type (sub $t (struct)))  ;; non-final, with supertype
(type (sub final $t (struct)))  ;; final, with supertype
```