### PR TITLE
[test] Add tentative JS API tests for Exported GC Object

### DIFF
--- a/test/js-api/gc/exported-object.tentative.any.js
+++ b/test/js-api/gc/exported-object.tentative.any.js
@@ -50,14 +50,10 @@ test(() => {
 test(() => {
   const struct = functions.makeStruct();
   const array = functions.makeArray();
-  struct.foo = 5;
-  assert_equals(struct.foo, undefined);
-  array.foo = 5;
-  assert_equals(array.foo, undefined);
-  struct[0] = 5;
-  assert_equals(struct[0], undefined);
-  array[0] = 5;
-  assert_equals(array[0], undefined);
+  assert_throws_js(TypeError, () => { struct.foo = 5; });
+  assert_throws_js(TypeError, () => { array.foo = 5; });
+  assert_throws_js(TypeError, () => { struct[0] = 5; });
+  assert_throws_js(TypeError, () => { array[0] = 5; });
 }, "property assignment (non-strict mode)");
 
 test(() => {
@@ -87,14 +83,10 @@ test(() => {
 test(() => {
   const struct = functions.makeStruct();
   const array = functions.makeArray();
-  const structNamesLength = Object.getOwnPropertyNames(struct).length;
-  const arrayNamesLength = Object.getOwnPropertyNames(array).length;
-  delete struct.foo;
-  delete struct[0];
-  delete array.foo;
-  delete array[0];
-  assert_equals(Object.getOwnPropertyNames(struct), structNamesLength);
-  assert_equals(Object.getOwnPropertyNames(array), arrayNamesLength);
+  assert_throws_js(TypeError, () => delete struct.foo);
+  assert_throws_js(TypeError, () => delete struct[0]);
+  assert_throws_js(TypeError, () => delete array.foo);
+  assert_throws_js(TypeError, () => delete array[0]);
 }, "delete (non-strict mode)");
 
 test(() => {

--- a/test/js-api/gc/exported-object.tentative.any.js
+++ b/test/js-api/gc/exported-object.tentative.any.js
@@ -72,8 +72,8 @@ test(() => {
 test(() => {
   const struct = functions.makeStruct()
   const array = functions.makeArray()
-  assert_throws_js(TypeError, () => Object.getPrototypeOf(struct));
-  assert_throws_js(TypeError, () => Object.getPrototypeOf(array));
+  assert_equals(Object.getPrototypeOf(struct), null);
+  assert_equals(Object.getPrototypeOf(array), null);
 }, "getPrototypeOf");
 
 test(() => {

--- a/test/js-api/gc/exported-object.tentative.any.js
+++ b/test/js-api/gc/exported-object.tentative.any.js
@@ -1,0 +1,160 @@
+// META: global=window,dedicatedworker,jsshell
+// META: script=/wasm/jsapi/wasm-module-builder.js
+
+let functions = {};
+setup(() => {
+  const builder = new WasmModuleBuilder();
+
+  const structIndex = builder.addStruct([makeField(kWasmI32, true)]);
+  const arrayIndex = builder.addArray(kWasmI32, true);
+  const structRef = wasmRefType(structIndex);
+  const arrayRef = wasmRefType(arrayIndex);
+
+  builder
+    .addFunction("makeStruct", makeSig_r_v(structRef))
+    .addBody([...wasmI32Const(42),
+              ...GCInstr(kExprStructNew), structIndex])
+    .exportFunc();
+
+  builder
+    .addFunction("makeArray", makeSig_r_v(arrayRef))
+    .addBody([...wasmI32Const(5), ...wasmI32Const(42),
+              ...GCInstr(kExprArrayNew), arrayIndex])
+    .exportFunc();
+
+  const buffer = builder.toBuffer()
+  const module = new WebAssembly.Module(buffer);
+  const instance = new WebAssembly.Instance(module, {});
+  functions = instance.exports;
+});
+
+test(() => {
+  const struct = functions.makeStruct()
+  const array = functions.makeArray()
+  assert_equals(struct.foo, undefined);
+  assert_equals(struct[0], undefined);
+  assert_equals(array.foo, undefined);
+  assert_equals(array[0], undefined);
+}, "property access");
+
+test(() => {
+  const struct = functions.makeStruct()
+  const array = functions.makeArray()
+  assert_throws_js(TypeError, () => { struct.foo = 5; });
+  assert_throws_js(TypeError, () => { array.foo = 5; });
+  assert_throws_js(TypeError, () => { struct[0] = 5; });
+  assert_throws_js(TypeError, () => { array[0] = 5; });
+}, "property assignment");
+
+test(() => {
+  const struct = functions.makeStruct()
+  const array = functions.makeArray()
+  assert_equals(Object.getOwnPropertyNames(struct).length, 0);
+  assert_equals(Object.getOwnPropertyNames(array).length, 0);
+}, "ownPropertyNames");
+
+test(() => {
+  const struct = functions.makeStruct()
+  const array = functions.makeArray()
+  assert_throws_js(TypeError, () => Object.defineProperty(struct, "foo", { value: 1 }));
+  assert_throws_js(TypeError, () => Object.defineProperty(array, "foo", { value: 1 }));
+}, "defineProperty");
+
+test(() => {
+  const struct = functions.makeStruct()
+  const array = functions.makeArray()
+  assert_throws_js(TypeError, () => delete struct.foo);
+  assert_throws_js(TypeError, () => delete struct[0]);
+  assert_throws_js(TypeError, () => delete array.foo);
+  assert_throws_js(TypeError, () => delete array[0]);
+}, "delete");
+
+test(() => {
+  const struct = functions.makeStruct()
+  const array = functions.makeArray()
+  assert_throws_js(TypeError, () => Object.getPrototypeOf(struct));
+  assert_throws_js(TypeError, () => Object.getPrototypeOf(array));
+}, "getPrototypeOf");
+
+test(() => {
+  const struct = functions.makeStruct()
+  const array = functions.makeArray()
+  assert_throws_js(TypeError, () => Object.setPrototypeOf(struct, {}));
+  assert_throws_js(TypeError, () => Object.setPrototypeOf(array, {}));
+}, "setPrototypeOf");
+
+test(() => {
+  const struct = functions.makeStruct()
+  const array = functions.makeArray()
+  assert_false(Object.isExtensible(struct));
+  assert_false(Object.isExtensible(array));
+}, "isExtensible");
+
+test(() => {
+  const struct = functions.makeStruct()
+  const array = functions.makeArray()
+  assert_throws_js(TypeError, () => Object.preventExtensions(struct));
+  assert_throws_js(TypeError, () => Object.preventExtensions(array));
+}, "preventExtensions");
+
+test(() => {
+  const struct = functions.makeStruct()
+  const array = functions.makeArray()
+  assert_throws_js(TypeError, () => Object.seal(struct));
+  assert_throws_js(TypeError, () => Object.seal(array));
+}, "sealing");
+
+test(() => {
+  const struct = functions.makeStruct()
+  const array = functions.makeArray()
+  assert_equals(typeof struct, "object");
+  assert_equals(typeof array, "object");
+}, "typeof");
+
+test(() => {
+  const struct = functions.makeStruct()
+  const array = functions.makeArray()
+  assert_throws_js(TypeError, () => struct.toString());
+  assert_equals(Object.prototype.toString.call(struct), "[object Object]");
+  assert_throws_js(TypeError, () => array.toString());
+  assert_equals(Object.prototype.toString.call(array), "[object Object]");
+}, "toString");
+
+test(() => {
+  const struct = functions.makeStruct()
+  const array = functions.makeArray()
+  assert_throws_js(TypeError, () => struct.valueOf());
+  assert_equals(Object.prototype.valueOf.call(struct), struct);
+  assert_throws_js(TypeError, () => array.valueOf());
+  assert_equals(Object.prototype.valueOf.call(array), array);
+}, "valueOf");
+
+test(() => {
+  const struct = functions.makeStruct()
+  const array = functions.makeArray()
+  const map = new Map();
+  map.set(struct, "struct");
+  map.set(array, "array");
+  assert_equals(map.get(struct), "struct");
+  assert_equals(map.get(array), "array");
+}, "GC objects as map keys");
+
+test(() => {
+  const struct = functions.makeStruct()
+  const array = functions.makeArray()
+  const set = new Set();
+  set.add(struct);
+  set.add(array);
+  assert_true(set.has(struct));
+  assert_true(set.has(array));
+}, "GC objects as set element");
+
+test(() => {
+  const struct = functions.makeStruct()
+  const array = functions.makeArray()
+  const map = new WeakMap();
+  map.set(struct, "struct");
+  map.set(array, "array");
+  assert_equals(map.get(struct), "struct");
+  assert_equals(map.get(array), "array");
+}, "GC objects as weak map keys");

--- a/test/js-api/gc/exported-object.tentative.any.js
+++ b/test/js-api/gc/exported-object.tentative.any.js
@@ -22,15 +22,15 @@ setup(() => {
               ...GCInstr(kExprArrayNew), arrayIndex])
     .exportFunc();
 
-  const buffer = builder.toBuffer()
+  const buffer = builder.toBuffer();
   const module = new WebAssembly.Module(buffer);
   const instance = new WebAssembly.Instance(module, {});
   functions = instance.exports;
 });
 
 test(() => {
-  const struct = functions.makeStruct()
-  const array = functions.makeArray()
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
   assert_equals(struct.foo, undefined);
   assert_equals(struct[0], undefined);
   assert_equals(array.foo, undefined);
@@ -38,82 +38,110 @@ test(() => {
 }, "property access");
 
 test(() => {
-  const struct = functions.makeStruct()
-  const array = functions.makeArray()
+  "use strict";
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
   assert_throws_js(TypeError, () => { struct.foo = 5; });
   assert_throws_js(TypeError, () => { array.foo = 5; });
   assert_throws_js(TypeError, () => { struct[0] = 5; });
   assert_throws_js(TypeError, () => { array[0] = 5; });
-}, "property assignment");
+}, "property assignment (strict mode)");
 
 test(() => {
-  const struct = functions.makeStruct()
-  const array = functions.makeArray()
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  struct.foo = 5;
+  assert_equals(struct.foo, undefined);
+  array.foo = 5;
+  assert_equals(array.foo, undefined);
+  struct[0] = 5;
+  assert_equals(struct[0], undefined);
+  array[0] = 5;
+  assert_equals(array[0], undefined);
+}, "property assignment (non-strict mode)");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
   assert_equals(Object.getOwnPropertyNames(struct).length, 0);
   assert_equals(Object.getOwnPropertyNames(array).length, 0);
 }, "ownPropertyNames");
 
 test(() => {
-  const struct = functions.makeStruct()
-  const array = functions.makeArray()
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
   assert_throws_js(TypeError, () => Object.defineProperty(struct, "foo", { value: 1 }));
   assert_throws_js(TypeError, () => Object.defineProperty(array, "foo", { value: 1 }));
 }, "defineProperty");
 
 test(() => {
-  const struct = functions.makeStruct()
-  const array = functions.makeArray()
+  "use strict";
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
   assert_throws_js(TypeError, () => delete struct.foo);
   assert_throws_js(TypeError, () => delete struct[0]);
   assert_throws_js(TypeError, () => delete array.foo);
   assert_throws_js(TypeError, () => delete array[0]);
-}, "delete");
+}, "delete (strict mode)");
 
 test(() => {
-  const struct = functions.makeStruct()
-  const array = functions.makeArray()
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  const structNamesLength = Object.getOwnPropertyNames(struct).length;
+  const arrayNamesLength = Object.getOwnPropertyNames(array).length;
+  delete struct.foo;
+  delete struct[0];
+  delete array.foo;
+  delete array[0];
+  assert_equals(Object.getOwnPropertyNames(struct), structNamesLength);
+  assert_equals(Object.getOwnPropertyNames(array), arrayNamesLength);
+}, "delete (non-strict mode)");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
   assert_equals(Object.getPrototypeOf(struct), null);
   assert_equals(Object.getPrototypeOf(array), null);
 }, "getPrototypeOf");
 
 test(() => {
-  const struct = functions.makeStruct()
-  const array = functions.makeArray()
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
   assert_throws_js(TypeError, () => Object.setPrototypeOf(struct, {}));
   assert_throws_js(TypeError, () => Object.setPrototypeOf(array, {}));
 }, "setPrototypeOf");
 
 test(() => {
-  const struct = functions.makeStruct()
-  const array = functions.makeArray()
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
   assert_false(Object.isExtensible(struct));
   assert_false(Object.isExtensible(array));
 }, "isExtensible");
 
 test(() => {
-  const struct = functions.makeStruct()
-  const array = functions.makeArray()
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
   assert_throws_js(TypeError, () => Object.preventExtensions(struct));
   assert_throws_js(TypeError, () => Object.preventExtensions(array));
 }, "preventExtensions");
 
 test(() => {
-  const struct = functions.makeStruct()
-  const array = functions.makeArray()
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
   assert_throws_js(TypeError, () => Object.seal(struct));
   assert_throws_js(TypeError, () => Object.seal(array));
 }, "sealing");
 
 test(() => {
-  const struct = functions.makeStruct()
-  const array = functions.makeArray()
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
   assert_equals(typeof struct, "object");
   assert_equals(typeof array, "object");
 }, "typeof");
 
 test(() => {
-  const struct = functions.makeStruct()
-  const array = functions.makeArray()
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
   assert_throws_js(TypeError, () => struct.toString());
   assert_equals(Object.prototype.toString.call(struct), "[object Object]");
   assert_throws_js(TypeError, () => array.toString());
@@ -121,8 +149,8 @@ test(() => {
 }, "toString");
 
 test(() => {
-  const struct = functions.makeStruct()
-  const array = functions.makeArray()
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
   assert_throws_js(TypeError, () => struct.valueOf());
   assert_equals(Object.prototype.valueOf.call(struct), struct);
   assert_throws_js(TypeError, () => array.valueOf());
@@ -130,8 +158,8 @@ test(() => {
 }, "valueOf");
 
 test(() => {
-  const struct = functions.makeStruct()
-  const array = functions.makeArray()
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
   const map = new Map();
   map.set(struct, "struct");
   map.set(array, "array");
@@ -140,8 +168,8 @@ test(() => {
 }, "GC objects as map keys");
 
 test(() => {
-  const struct = functions.makeStruct()
-  const array = functions.makeArray()
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
   const set = new Set();
   set.add(struct);
   set.add(array);
@@ -150,11 +178,21 @@ test(() => {
 }, "GC objects as set element");
 
 test(() => {
-  const struct = functions.makeStruct()
-  const array = functions.makeArray()
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
   const map = new WeakMap();
   map.set(struct, "struct");
   map.set(array, "array");
   assert_equals(map.get(struct), "struct");
   assert_equals(map.get(array), "array");
 }, "GC objects as weak map keys");
+
+test(() => {
+  const struct = functions.makeStruct();
+  const array = functions.makeArray();
+  const set = new WeakSet();
+  set.add(struct);
+  set.add(array);
+  assert_true(set.has(struct));
+  assert_true(set.has(array));
+}, "GC objects as weak set element");

--- a/test/js-api/wasm-module-builder.js
+++ b/test/js-api/wasm-module-builder.js
@@ -402,22 +402,32 @@ function GCInstr(opcode) {
 }
 
 // GC opcodes
-let kExprStructNew = 0x01;
-let kExprStructNewDefault = 0x02;
+// Opcodes with "Canon" are opcode numbers from the specification.
+// The non-"Canon" variants such as kExprStructNew are de-facto
+// opcode numbers that are in use in some web engine implementations.
+let kExprStructNewCanon = 0x01;
+let kExprStructNewCanonDefault = 0x02;
 let kExprStructGet = 0x03;
 let kExprStructGetS = 0x04;
 let kExprStructGetU = 0x05;
 let kExprStructSet = 0x06;
-let kExprArrayNew = 0x11;
-let kExprArrayNewDefault = 0x12;
+let kExprStructNew = 0x07;
+let kExprStructNewDefault = 0x08;
+let kExprArrayNewCanon = 0x11;
+let kExprArrayNewCanonDefault = 0x12;
 let kExprArrayGet = 0x13;
 let kExprArrayGetS = 0x14;
 let kExprArrayGetU = 0x15;
 let kExprArraySet = 0x16;
 let kExprArrayLen = 0x17;
-let kExprArrayNewFixed = 0x19;
-let kExprArrayNewData = 0x1b;
-let kExprArrayNewElem = 0x1c;
+let kExprArrayNewCanonFixed = 0x19;
+let kExprArrayNewFixed = 0x1a;
+let kExprArrayNew = 0x1b;
+let kExprArrayNewDefault = 0x1c;
+let kExprArrayNewCanonData = 0x1b;
+let kExprArrayNewCanonElem = 0x1c;
+let kExprArrayNewData = 0x1d;
+let kExprArrayNewElem = 0x1f;
 let kExprI31New = 0x20;
 let kExprI31GetS = 0x21;
 let kExprI31GetU = 0x22;

--- a/test/js-api/wasm-module-builder.js
+++ b/test/js-api/wasm-module-builder.js
@@ -402,45 +402,37 @@ function GCInstr(opcode) {
 }
 
 // GC opcodes
-// Opcodes with "Canon" are opcode numbers from the specification.
-// The non-"Canon" variants such as kExprStructNew are de-facto
-// opcode numbers that are in use in some web engine implementations.
-let kExprStructNewCanon = 0x01;
-let kExprStructNewCanonDefault = 0x02;
-let kExprStructGet = 0x03;
-let kExprStructGetS = 0x04;
-let kExprStructGetU = 0x05;
-let kExprStructSet = 0x06;
-let kExprStructNew = 0x07;
-let kExprStructNewDefault = 0x08;
-let kExprArrayNewCanon = 0x11;
-let kExprArrayNewCanonDefault = 0x12;
-let kExprArrayGet = 0x13;
-let kExprArrayGetS = 0x14;
-let kExprArrayGetU = 0x15;
-let kExprArraySet = 0x16;
-let kExprArrayLen = 0x17;
-let kExprArrayNewCanonFixed = 0x19;
-let kExprArrayNewFixed = 0x1a;
-let kExprArrayNew = 0x1b;
-let kExprArrayNewDefault = 0x1c;
-let kExprArrayNewCanonData = 0x1b;
-let kExprArrayNewCanonElem = 0x1c;
-let kExprArrayNewData = 0x1d;
-let kExprArrayNewElem = 0x1f;
-let kExprI31New = 0x20;
-let kExprI31GetS = 0x21;
-let kExprI31GetU = 0x22;
-let kExprRefTest = 0x40;
-let kExprRefTestNull = 0x48;
-let kExprRefCast = 0x41;
-let kExprRefCastNull = 0x49;
-let kExprBrOnCast = 0x42;
-let kExprBrOnCastNull = 0x4a;
-let kExprBrOnCastFail = 0x43;
-let kExprBrOnCastFailNull = 0x4b;
-let kExprExternInternalize = 0x70;
-let kExprExternExternalize = 0x71;
+let kExprStructNew = 0x00;
+let kExprStructNewDefault = 0x01;
+let kExprStructGet = 0x02;
+let kExprStructGetS = 0x03;
+let kExprStructGetU = 0x04;
+let kExprStructSet = 0x05;
+let kExprArrayNew = 0x06;
+let kExprArrayNewDefault = 0x07;
+let kExprArrayNewFixed = 0x08;
+let kExprArrayNewData = 0x09;
+let kExprArrayNewElem = 0x0a;
+let kExprArrayGet = 0x0b;
+let kExprArrayGetS = 0x0c;
+let kExprArrayGetU = 0x0d;
+let kExprArraySet = 0x0e;
+let kExprArrayLen = 0x0f;
+let kExprArrayFill = 0x10;
+let kExprArrayCopy = 0x11;
+let kExprArrayInitData = 0x12;
+let kExprArrayInitElem = 0x13;
+let kExprRefTest = 0x14;
+let kExprRefTestNull = 0x15;
+let kExprRefCast = 0x16;
+let kExprRefCastNull = 0x17;
+let kExprBrOnCast = 0x18;
+let kExprBrOnCastFail = 0x19;
+let kExprExternInternalize = 0x1a;
+let kExprExternExternalize = 0x1b;
+let kExprI31New = 0x1c;
+let kExprI31GetS = 0x1d;
+let kExprI31GetU = 0x1e;
 
 // Numeric opcodes.
 let kExprMemoryInit = 0x08;


### PR DESCRIPTION
Adds tests for the "Exported GC Object" described in the proposed JS API spec in https://github.com/WebAssembly/gc/pull/352.

This requires updating the wasm module builder helper library, which is now fairly de-synced with the V8 library it's based on. I've only synced a bare minimum in this PR to be able to construct some GC modules (syncing the whole thing causes other tests to fail).

The V8 version also uses a slightly different opcode numbering than the current spec document in this repo. In this PR I went with the spec numbering (in the end they will all need to be synchronized).

This doesn't have tests for all the ToWasmValue/ToJSValue cases for conversions, which would also be useful to add.