### PR TITLE
Add array instructions to MVP

### DIFF
--- a/proposals/gc/MVP.md
+++ b/proposals/gc/MVP.md
@@ -808,6 +808,7 @@ The opcode for heap types is encoded as an `s33`.
 | 0xfb04 | `struct.get_s $t i` | `$t : typeidx`, `i : fieldidx` |
 | 0xfb05 | `struct.get_u $t i` | `$t : typeidx`, `i : fieldidx` |
 | 0xfb06 | `struct.set $t i` | `$t : typeidx`, `i : fieldidx` |
+| 0xfb0f | `array.fill $t` | `$t : typeidx` |
 | 0xfb11 | `array.new $t` | `$t : typeidx` |
 | 0xfb12 | `array.new_default $t` | `$t : typeidx` |
 | 0xfb13 | `array.get $t` | `$t : typeidx` |
@@ -815,6 +816,7 @@ The opcode for heap types is encoded as an `s33`.
 | 0xfb15 | `array.get_u $t` | `$t : typeidx` |
 | 0xfb16 | `array.set $t` | `$t : typeidx` |
 | 0xfb17 | `array.len` | |
+| 0xfb18 | `array.copy $t1 $t2` | `$t1 : typeidx`, `$t2 : typeidx` |
 | 0xfb19 | `array.new_fixed $t N` | `$t : typeidx`, `N : u32` |
 | 0xfb1b | `array.new_data $t $d` | `$t : typeidx`, `$d : dataidx` |
 | 0xfb1c | `array.new_elem $t $e` | `$t : typeidx`, `$e : elemidx` |
@@ -827,6 +829,8 @@ The opcode for heap types is encoded as an `s33`.
 | 0xfb49 | `ref.cast (ref null ht)` | `ht : heaptype` |
 | 0xfb4e | `br_on_cast $l (ref null1? ht1) (ref null2? ht2)` | `flags : u8`, $l : labelidx`, `ht1 : heaptype`, `ht2 : heaptype` |
 | 0xfb4f | `br_on_cast_fail $l (ref null1? ht1) (ref null2? ht2)` | `flags : u8`, $l : labelidx`, `ht1 : heaptype`, `ht2 : heaptype` |
+| 0xfb54 | `array.init_data $t $d` | `$t : typeidx`, `$d: dataidx` |
+| 0xfb55 | `array.init_elem $t $e` | `$t : typeidx`, `$d: elemidx` |
 | 0xfb70 | `extern.internalize` | |
 | 0xfb71 | `extern.externalize` | |
 


### PR DESCRIPTION
This adds the bulk array instructions to the instruction list in the binary format of the MVP markdown.