### PR TITLE
Fix JS conversion

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -411,10 +411,16 @@ let is_js_num_type = function
   | I32T -> true
   | I64T | F32T | F64T -> false
 
+let is_js_heap_type = function
+  | AnyHT | EqHT | I31HT | StructHT | ArrayHT -> false
+  | FuncHT | ExternHT -> true
+  | NoneHT | NoFuncHT | NoExternHT -> assert false
+  | VarHT _ | DefHT _ | BotHT -> assert false
+
 let is_js_val_type = function
   | NumT t -> is_js_num_type t
   | VecT _ -> false
-  | RefT _ -> true
+  | RefT (_, ht) -> is_js_heap_type ht
   | BotT -> assert false
 
 let is_js_global_type = function

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -11,18 +11,18 @@ let harness =
 {|
 'use strict';
 
-let externrefs = {};
-let externsym = Symbol("externref");
-function externref(s) {
-  if (! (s in externrefs)) externrefs[s] = {[externsym]: s};
-  return externrefs[s];
+let hostrefs = {};
+let hostsym = Symbol("hostref");
+function hostref(s) {
+  if (! (s in hostrefs)) hostrefs[s] = {[hostsym]: s};
+  return hostrefs[s];
 }
 function eq_ref(x, y) {
   return x === y ? 1 : 0;
 }
 
 let spectest = {
-  externref: externref,
+  hostref: hostref,
   eq_ref: eq_ref,
   print: console.log.bind(console),
   print_i32: console.log.bind(console),
@@ -222,7 +222,7 @@ let lookup (mods : modules) x_opt name at =
 (* Wrappers *)
 
 let subject_idx = 0l
-let externref_idx = 1l
+let hostref_idx = 1l
 let eq_ref_idx = 2l
 let subject_type_idx = 3l
 
@@ -256,7 +256,7 @@ let value v =
   | Vec s -> [VecConst (s @@ v.at) @@ v.at]
   | Ref (NullRef ht) -> [RefNull (Match.bot_of_heap_type [] ht) @@ v.at]
   | Ref (Extern.ExternRef (HostRef n)) ->
-    [Const (I32 n @@ v.at) @@ v.at; Call (externref_idx @@ v.at) @@ v.at]
+    [Const (I32 n @@ v.at) @@ v.at; Call (hostref_idx @@ v.at) @@ v.at]
   | Ref _ -> assert false
 
 let invoke ft vs at =
@@ -348,7 +348,7 @@ let assert_return ress ts at =
         BrIf (0l @@ at) @@ at ]
     | RefResult (RefPat {it = HostRef n; _}) ->
       [ Const (Value.I32 n @@ at) @@ at;
-        Call (externref_idx @@ at) @@ at;
+        Call (hostref_idx @@ at) @@ at;
         Call (eq_ref_idx @@ at)  @@ at;
         Test (Value.I32 I32Op.Eqz) @@ at;
         BrIf (0l @@ at) @@ at ]
@@ -384,7 +384,7 @@ let wrap item_name wrap_action wrap_assertion at =
   in
   let imports =
     [ {module_name = Utf8.decode "module"; item_name; idesc} @@ at;
-      {module_name = Utf8.decode "spectest"; item_name = Utf8.decode "externref";
+      {module_name = Utf8.decode "spectest"; item_name = Utf8.decode "hostref";
        idesc = FuncImport (1l @@ at) @@ at} @@ at;
       {module_name = Utf8.decode "spectest"; item_name = Utf8.decode "eq_ref";
        idesc = FuncImport (3l @@ at) @@ at} @@ at;

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -157,6 +157,21 @@ function assert_return(action, ...expected) {
           throw new Error("Wasm return value NaN expected, got " + actual[i]);
         };
         return;
+      case "ref.i31":
+        if (typeof actual[i] !== "number" || (actual[i] & 0x7fffffff) !== actual[i]) {
+          throw new Error("Wasm i31 return value expected, got " + actual[i]);
+        };
+        return;
+      case "ref.any":
+      case "ref.eq":
+      case "ref.struct":
+      case "ref.array":
+        // For now, JS can't distinguish exported Wasm GC values,
+        // so we only test for object.
+        if (typeof actual[i] !== "object") {
+          throw new Error("Wasm function return value expected, got " + actual[i]);
+        };
+        return;
       case "ref.func":
         if (typeof actual[i] !== "function") {
           throw new Error("Wasm function return value expected, got " + actual[i]);
@@ -411,16 +426,10 @@ let is_js_num_type = function
   | I32T -> true
   | I64T | F32T | F64T -> false
 
-let is_js_heap_type = function
-  | AnyHT | EqHT | I31HT | StructHT | ArrayHT -> false
-  | FuncHT | ExternHT -> true
-  | NoneHT | NoFuncHT | NoExternHT -> assert false
-  | VarHT _ | DefHT _ | BotHT -> assert false
-
 let is_js_val_type = function
   | NumT t -> is_js_num_type t
   | VecT _ -> false
-  | RefT (_, ht) -> is_js_heap_type ht
+  | RefT _ -> true
   | BotT -> assert false
 
 let is_js_global_type = function

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -387,7 +387,7 @@ let wrap item_name wrap_action wrap_assertion at =
       {module_name = Utf8.decode "spectest"; item_name = Utf8.decode "hostref";
        idesc = FuncImport (1l @@ at) @@ at} @@ at;
       {module_name = Utf8.decode "spectest"; item_name = Utf8.decode "eq_ref";
-       idesc = FuncImport (3l @@ at) @@ at} @@ at;
+       idesc = FuncImport (2l @@ at) @@ at} @@ at;
     ]
   in
   let item =


### PR DESCRIPTION
Should fix issues listed in #396.

Right now, JS-converted tests cannot distinguish ref.array and ref.struct results. But there are only 4 tests doing this, and they are fairly trivial, so that imprecision should be fine for now. (We already have a similar imprecision with tests inspecting NaN results.)