### PR TITLE
Make type setting of i8.pack and i16.pack less jarring

### DIFF
--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -506,7 +506,7 @@ Conventions
   .. math::
      \begin{array}{@{}lcl}
      \packval_{\valtype}(\val) &=& \val \\
-     \packval_{\packedtype}(\I32.\CONST~i) &=& \packedtype\K{.PACK}~(\wrap_{32,|\packtype|}(i))
+     \packval_{\packedtype}(\I32.\CONST~i) &=& \packedtype\K{.pack}~(\wrap_{32,|\packtype|}(i))
      \end{array}
 
 * The inverse conversion of a :ref:`field value <syntax-fieldval>` to a regular :ref:`value <syntax-val>` is defined as follows:
@@ -514,7 +514,7 @@ Conventions
   .. math::
      \begin{array}{@{}lcl}
      \unpackval_{\valtype}(\val) &=& \val \\
-     \unpackval^{\sx}_{\packedtype}(\packedtype\K{.PACK}~i) &=& \I32.\CONST~(\extend^{\sx}_{|\packedtype|,32}(i))
+     \unpackval^{\sx}_{\packedtype}(\packedtype\K{.pack}~i) &=& \I32.\CONST~(\extend^{\sx}_{|\packedtype|,32}(i))
      \end{array}
 
 

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -1191,8 +1191,8 @@
 .. |AITYPE| mathdef:: \xref{exec/runtime}{syntax-arrayinst}{\K{type}}
 .. |AIFIELDS| mathdef:: \xref{exec/runtime}{syntax-arrayinst}{\K{fields}}
 
-.. |I8PACK| mathdef:: \xref{exec/runtime}{syntax-packval}{\K{I8.PACK}}
-.. |I16PACK| mathdef:: \xref{exec/runtime}{syntax-packval}{\K{I16.PACK}}
+.. |I8PACK| mathdef:: \xref{exec/runtime}{syntax-packval}{\K{i8.pack}}
+.. |I16PACK| mathdef:: \xref{exec/runtime}{syntax-packval}{\K{i16.pack}}
 
 
 .. Instances, non-terminals


### PR DESCRIPTION
Having I8.PACK and I16.PACK in sans serif was visually very jarring and felt
inconsistent with other similar values in the spec. Change these to lowercase
for consistency and to make it look much better.