### PR TITLE
Use `open` instead of `final` in the text format

### DIFF
--- a/document/core/text/types.rst
+++ b/document/core/text/types.rst
@@ -85,8 +85,8 @@ Abbreviations
 There are shorthands for references to abstract heap types.
 
 .. math::
-   \begin{array}{llclll}
-   \production{reference type} &
+   \begin{array}{lcl}
+   \production{reference type}
      \text{anyref} &\equiv& \text{(}~\text{ref}~~\text{null}~~\text{any}~\text{)} \\
      \text{eqref} &\equiv& \text{(}~\text{ref}~~\text{null}~~\text{eq}~\text{)} \\
      \text{i31ref} &\equiv& \text{(}~\text{ref}~~\text{null}~~\text{i31}~\text{)} \\
@@ -255,30 +255,33 @@ Recursive Types
      \text{(}~\text{type}~~\Tid^?~~\X{st}{:}\Tsubtype_I~\text{)}
        &\Rightarrow& \X{st} \\
    \production{sub type} & \Tsubtype_I &::=&
-     \text{(}~\text{sub}~~\text{final}^?~~x^\ast{:\,}\Tvec(\Ttypeidx_I)~~\X{ct}{:}\Tcomptype_I~\text{)}
+     \text{(}~\text{sub}~~\text{open}^?~~x^\ast{:\,}\Tvec(\Ttypeidx_I)~~\X{ct}{:}\Tcomptype_I~\text{)}
        &\Rightarrow& \TSUB~\TFINAL^?~x^\ast~\X{ct} \\
    \end{array}
+
+.. note::
+   A subtype is :ref:`final <syntax-subtype>` if the :math:`\text{open}` keyword is not present, and vice versa.
 
 
 Abbreviations
 .............
 
-Singular recursive types can omit the |Trec| keyword:
+Singular recursive types can omit the :math:`\text{rec}` keyword:
 
 .. math::
-   \begin{array}{llclll}
+   \begin{array}{lcl}
    \production{recursive type} &
-     \Tsubtype &\equiv&
-     \text{(}~~\text{rec}~~\Tsubtype~~\text{)} \\
+     \Tdeftype &\equiv&
+     \text{(}~~\text{rec}~~\Tdeftype~~\text{)} \\
    \end{array}
 
-Similarly, final sub types with no super-types can omit the |Tsub| keyword and arguments:
+Similarly, final sub types with no super-types can omit the :math:`\text{sub}` keyword:
 
 .. math::
-   \begin{array}{llclll}
+   \begin{array}{lcl}
    \production{sub type} &
      \Tcomptype &\equiv&
-     \text{(}~~\text{sub}~~\text{final}~~\epsilon~~\Tcomptype~~\text{)} \\
+     \text{(}~~\text{sub}~~\Tcomptype~~\text{)} \\
    \end{array}
 
 

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -308,8 +308,8 @@ let string_of_null = function
   | Null -> "null "
 
 let string_of_final = function
-  | NoFinal -> ""
-  | Final -> " final"
+  | NoFinal -> " open"
+  | Final -> ""
 
 let string_of_mut s = function
   | Cons -> s

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -78,8 +78,8 @@ let val_type t = string_of_val_type t
 let storage_type t = string_of_storage_type t
 
 let final = function
-  | NoFinal -> ""
-  | Final -> " final"
+  | NoFinal -> " open"
+  | Final -> ""
 
 let decls kind ts = tab kind (atom val_type) ts
 

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -175,7 +175,7 @@ rule token = parse
       | "field" -> FIELD
       | "mut" -> MUT
       | "sub" -> SUB
-      | "final" -> FINAL
+      | "open" -> OPEN
       | "rec" -> REC
 
       | "nop" -> NOP

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -257,7 +257,7 @@ let inline_func_type_explicit (c : context) x ft at =
 %token ANYREF NULLREF EQREF I31REF STRUCTREF ARRAYREF
 %token FUNCREF NULLFUNCREF EXTERNREF NULLEXTERNREF
 %token ANY NONE EQ I31 REF NOFUNC EXTERN NOEXTERN NULL
-%token MUT FIELD STRUCT ARRAY SUB FINAL REC
+%token MUT FIELD STRUCT ARRAY SUB OPEN REC
 %token UNREACHABLE NOP DROP SELECT
 %token BLOCK END IF THEN ELSE LOOP
 %token BR BR_IF BR_TABLE
@@ -414,10 +414,10 @@ str_type :
 sub_type :
   | str_type { fun c x -> SubT (Final, [], $1 c x) }
   | LPAR SUB var_list str_type RPAR
-    { fun c x -> SubT (NoFinal,
-        List.map (fun y -> VarHT (StatX y.it)) ($3 c type_), $4 c x) }
-  | LPAR SUB FINAL var_list str_type RPAR
     { fun c x -> SubT (Final,
+        List.map (fun y -> VarHT (StatX y.it)) ($3 c type_), $4 c x) }
+  | LPAR SUB OPEN var_list str_type RPAR
+    { fun c x -> SubT (NoFinal,
         List.map (fun y -> VarHT (StatX y.it)) ($4 c type_), $5 c x) }
 
 table_type :

--- a/test/core/gc/br_on_cast.wast
+++ b/test/core/gc/br_on_cast.wast
@@ -102,14 +102,14 @@
 ;; Concrete Types
 
 (module
-  (type $t0 (sub (struct)))
-  (type $t1 (sub $t0 (struct (field i32))))
-  (type $t1' (sub $t0 (struct (field i32))))
-  (type $t2 (sub $t1 (struct (field i32 i32))))
-  (type $t2' (sub $t1' (struct (field i32 i32))))
-  (type $t3 (sub $t0 (struct (field i32 i32))))
-  (type $t0' (sub $t0 (struct)))
-  (type $t4 (sub $t0' (struct (field i32 i32))))
+  (type $t0 (sub open (struct)))
+  (type $t1 (sub open $t0 (struct (field i32))))
+  (type $t1' (sub open $t0 (struct (field i32))))
+  (type $t2 (sub open $t1 (struct (field i32 i32))))
+  (type $t2' (sub open $t1' (struct (field i32 i32))))
+  (type $t3 (sub open $t0 (struct (field i32 i32))))
+  (type $t0' (sub open $t0 (struct)))
+  (type $t4 (sub open $t0' (struct (field i32 i32))))
 
   (table 20 structref)
 

--- a/test/core/gc/br_on_cast_fail.wast
+++ b/test/core/gc/br_on_cast_fail.wast
@@ -102,14 +102,14 @@
 ;; Concrete Types
 
 (module
-  (type $t0 (sub (struct)))
-  (type $t1 (sub $t0 (struct (field i32))))
-  (type $t1' (sub $t0 (struct (field i32))))
-  (type $t2 (sub $t1 (struct (field i32 i32))))
-  (type $t2' (sub $t1' (struct (field i32 i32))))
-  (type $t3 (sub $t0 (struct (field i32 i32))))
-  (type $t0' (sub $t0 (struct)))
-  (type $t4 (sub $t0' (struct (field i32 i32))))
+  (type $t0 (sub open (struct)))
+  (type $t1 (sub open $t0 (struct (field i32))))
+  (type $t1' (sub open $t0 (struct (field i32))))
+  (type $t2 (sub open $t1 (struct (field i32 i32))))
+  (type $t2' (sub open $t1' (struct (field i32 i32))))
+  (type $t3 (sub open $t0 (struct (field i32 i32))))
+  (type $t0' (sub open $t0 (struct)))
+  (type $t4 (sub open $t0' (struct (field i32 i32))))
 
   (table 20 structref)
 

--- a/test/core/gc/ref_cast.wast
+++ b/test/core/gc/ref_cast.wast
@@ -97,14 +97,14 @@
 ;; Concrete Types
 
 (module
-  (type $t0 (sub (struct)))
-  (type $t1 (sub $t0 (struct (field i32))))
-  (type $t1' (sub $t0 (struct (field i32))))
-  (type $t2 (sub $t1 (struct (field i32 i32))))
-  (type $t2' (sub $t1' (struct (field i32 i32))))
-  (type $t3 (sub $t0 (struct (field i32 i32))))
-  (type $t0' (sub $t0 (struct)))
-  (type $t4 (sub $t0' (struct (field i32 i32))))
+  (type $t0 (sub open (struct)))
+  (type $t1 (sub open $t0 (struct (field i32))))
+  (type $t1' (sub open $t0 (struct (field i32))))
+  (type $t2 (sub open $t1 (struct (field i32 i32))))
+  (type $t2' (sub open $t1' (struct (field i32 i32))))
+  (type $t3 (sub open $t0 (struct (field i32 i32))))
+  (type $t0' (sub open $t0 (struct)))
+  (type $t4 (sub open $t0' (struct (field i32 i32))))
 
   (table 20 (ref null struct))
 

--- a/test/core/gc/ref_eq.wast
+++ b/test/core/gc/ref_eq.wast
@@ -1,6 +1,6 @@
 (module
-  (type $st (sub (struct)))
-  (type $st' (sub (struct (field i32))))
+  (type $st (sub open (struct)))
+  (type $st' (sub open (struct (field i32))))
   (type $at (array i8))
   (type $st-sub1 (sub $st (struct)))
   (type $st-sub2 (sub $st (struct)))

--- a/test/core/gc/ref_test.wast
+++ b/test/core/gc/ref_test.wast
@@ -180,14 +180,14 @@
 ;; Concrete Types
 
 (module
-  (type $t0 (sub (struct)))
-  (type $t1 (sub $t0 (struct (field i32))))
-  (type $t1' (sub $t0 (struct (field i32))))
-  (type $t2 (sub $t1 (struct (field i32 i32))))
-  (type $t2' (sub $t1' (struct (field i32 i32))))
-  (type $t3 (sub $t0 (struct (field i32 i32))))
-  (type $t0' (sub $t0 (struct)))
-  (type $t4 (sub $t0' (struct (field i32 i32))))
+  (type $t0 (sub open (struct)))
+  (type $t1 (sub open $t0 (struct (field i32))))
+  (type $t1' (sub open $t0 (struct (field i32))))
+  (type $t2 (sub open $t1 (struct (field i32 i32))))
+  (type $t2' (sub open $t1' (struct (field i32 i32))))
+  (type $t3 (sub open $t0 (struct (field i32 i32))))
+  (type $t0' (sub open $t0 (struct)))
+  (type $t4 (sub open $t0' (struct (field i32 i32))))
 
   (table 20 (ref null struct))
 

--- a/test/core/gc/type-subtyping.wast
+++ b/test/core/gc/type-subtyping.wast
@@ -1,48 +1,48 @@
 ;; Definitions
 
 (module
-  (type $e0 (sub (array i32)))
-  (type $e1 (sub $e0 (array i32)))
+  (type $e0 (sub open (array i32)))
+  (type $e1 (sub open $e0 (array i32)))
 
   (type $e2 (sub (array anyref)))
   (type $e3 (sub (array (ref null $e0))))
   (type $e4 (sub (array (ref $e1))))
 
-  (type $m1 (sub (array (mut i32))))
-  (type $m2 (sub $m1 (array (mut i32))))
+  (type $m1 (sub open (array (mut i32))))
+  (type $m2 (sub open $m1 (array (mut i32))))
 )
 
 (module
-  (type $e0 (sub (struct)))
-  (type $e1 (sub $e0 (struct)))
-  (type $e2 (sub $e1 (struct (field i32))))
-  (type $e3 (sub $e2 (struct (field i32 (ref null $e0)))))
-  (type $e4 (sub $e3 (struct (field i32 (ref $e0) (mut i64)))))
+  (type $e0 (sub open (struct)))
+  (type $e1 (sub open $e0 (struct)))
+  (type $e2 (sub open $e1 (struct (field i32))))
+  (type $e3 (sub open $e2 (struct (field i32 (ref null $e0)))))
+  (type $e4 (sub open $e3 (struct (field i32 (ref $e0) (mut i64)))))
   (type $e5 (sub $e4 (struct (field i32 (ref $e1) (mut i64)))))
 )
 
 (module
-  (type $s (sub (struct)))
-  (type $s' (sub $s (struct)))
+  (type $s (sub open (struct)))
+  (type $s' (sub open $s (struct)))
 
-  (type $f1 (sub (func (param (ref $s')) (result anyref))))
-  (type $f2 (sub $f1 (func (param (ref $s)) (result (ref any)))))
-  (type $f3 (sub $f2 (func (param (ref null $s)) (result (ref $s)))))
-  (type $f4 (sub $f3 (func (param (ref null struct)) (result (ref $s')))))
+  (type $f1 (sub open (func (param (ref $s')) (result anyref))))
+  (type $f2 (sub open $f1 (func (param (ref $s)) (result (ref any)))))
+  (type $f3 (sub open $f2 (func (param (ref null $s)) (result (ref $s)))))
+  (type $f4 (sub open $f3 (func (param (ref null struct)) (result (ref $s')))))
 )
 
 
 ;; Recursive definitions
 
 (module
-  (type $t (sub (struct (field anyref))))
-  (rec (type $r (sub $t (struct (field (ref $r))))))
-  (type $t' (sub $r (struct (field (ref $r) i32))))
+  (type $t (sub open (struct (field anyref))))
+  (rec (type $r (sub open $t (struct (field (ref $r))))))
+  (type $t' (sub open $r (struct (field (ref $r) i32))))
 )
 
 (module
   (rec
-    (type $r1 (sub (struct (field i32 (ref $r1)))))
+    (type $r1 (sub open (struct (field i32 (ref $r1)))))
   )
   (rec
     (type $r2 (sub $r1 (struct (field i32 (ref $r3)))))
@@ -52,8 +52,8 @@
 
 (module
   (rec
-    (type $a1 (sub (struct (field i32 (ref $a2)))))
-    (type $a2 (sub (struct (field i64 (ref $a1)))))
+    (type $a1 (sub open (struct (field i32 (ref $a2)))))
+    (type $a2 (sub open (struct (field i64 (ref $a1)))))
   )
   (rec
     (type $b1 (sub $a2 (struct (field i64 (ref $a1) i32))))
@@ -67,9 +67,9 @@
 
 (module
   (rec
-    (type $t1 (sub (func (param i32 (ref $t3)))))
-    (type $t2 (sub $t1 (func (param i32 (ref $t2)))))
-    (type $t3 (sub $t2 (func (param i32 (ref $t1)))))
+    (type $t1 (sub open (func (param i32 (ref $t3)))))
+    (type $t2 (sub open $t1 (func (param i32 (ref $t2)))))
+    (type $t3 (sub open $t2 (func (param i32 (ref $t1)))))
   )
 
   (func $f1 (param $r (ref $t1))
@@ -88,8 +88,8 @@
 
 (module
   (rec
-    (type $t1 (sub (func (result i32 (ref $u1)))))
-    (type $u1 (sub (func (result f32 (ref $t1)))))
+    (type $t1 (sub open (func (result i32 (ref $u1)))))
+    (type $u1 (sub open (func (result f32 (ref $t1)))))
   )
 
   (rec
@@ -113,8 +113,8 @@
 )
 
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f2)))))
   (rec (type $g1 (sub $f1 (func))) (type (struct)))
   (rec (type $g2 (sub $f2 (func))) (type (struct)))
   (func $g (type $g2))
@@ -122,8 +122,8 @@
 )
 
 (module
-  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
-  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec (type $f1 (sub open (func))) (type $s1 (sub open (struct (field (ref $f1))))))
+  (rec (type $f2 (sub open (func))) (type $s2 (sub open (struct (field (ref $f2))))))
   (rec
     (type $g1 (sub $f1 (func)))
     (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
@@ -138,8 +138,8 @@
 
 (assert_invalid
   (module
-    (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-    (rec (type $f2 (sub (func))) (type (struct (field (ref $f1)))))
+    (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+    (rec (type $f2 (sub open (func))) (type (struct (field (ref $f1)))))
     (rec (type $g1 (sub $f1 (func))) (type (struct)))
     (rec (type $g2 (sub $f2 (func))) (type (struct)))
     (func $g (type $g2))
@@ -149,22 +149,22 @@
 )
 
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f2)))))
   (rec (type $g (sub $f1 (func))) (type (struct)))
   (func $g (type $g))
   (global (ref $f1) (ref.func $g))
 )
 
 (module
-  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
-  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec (type $f1 (sub open (func))) (type $s1 (sub open (struct (field (ref $f1))))))
+  (rec (type $f2 (sub open (func))) (type $s2 (sub open (struct (field (ref $f2))))))
   (rec
-    (type $g1 (sub $f1 (func)))
+    (type $g1 (sub open $f1 (func)))
     (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
   )
   (rec
-    (type $g2 (sub $f2 (func)))
+    (type $g2 (sub open $f2 (func)))
     (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
   )
   (rec (type $h (sub $g2 (func))) (type (struct)))
@@ -175,8 +175,8 @@
 
 
 (module
-  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
-  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
+  (rec (type $f11 (sub open (func (result (ref func))))) (type $f12 (sub open $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub open (func (result (ref func))))) (type $f22 (sub open $f21 (func (result (ref $f21))))))
   (func $f11 (type $f11) (unreachable))
   (func $f12 (type $f12) (unreachable))
   (global (ref $f11) (ref.func $f11))
@@ -186,10 +186,10 @@
 )
 
 (module
-  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
-  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
-  (rec (type $g11 (sub $f11 (func (result (ref func))))) (type $g12 (sub $g11 (func (result (ref $g11))))))
-  (rec (type $g21 (sub $f21 (func (result (ref func))))) (type $g22 (sub $g21 (func (result (ref $g21))))))
+  (rec (type $f11 (sub open (func (result (ref func))))) (type $f12 (sub open $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub open (func (result (ref func))))) (type $f22 (sub open $f21 (func (result (ref $f21))))))
+  (rec (type $g11 (sub open $f11 (func (result (ref func))))) (type $g12 (sub open $g11 (func (result (ref $g11))))))
+  (rec (type $g21 (sub open $f21 (func (result (ref func))))) (type $g22 (sub open $g21 (func (result (ref $g21))))))
   (func $g11 (type $g11) (unreachable))
   (func $g12 (type $g12) (unreachable))
   (global (ref $f11) (ref.func $g11))
@@ -204,8 +204,8 @@
 
 (assert_invalid
   (module
-    (rec (type $f11 (sub (func))) (type $f12 (sub $f11 (func))))
-    (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+    (rec (type $f11 (sub open (func))) (type $f12 (sub open $f11 (func))))
+    (rec (type $f21 (sub open (func))) (type $f22 (sub open $f11 (func))))
     (func $f (type $f21))
     (global (ref $f11) (ref.func $f))
   )
@@ -214,9 +214,9 @@
 
 (assert_invalid
   (module
-    (rec (type $f01 (sub (func))) (type $f02 (sub $f01 (func))))
-    (rec (type $f11 (sub (func))) (type $f12 (sub $f01 (func))))
-    (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+    (rec (type $f01 (sub open (func))) (type $f02 (sub open $f01 (func))))
+    (rec (type $f11 (sub open (func))) (type $f12 (sub open $f01 (func))))
+    (rec (type $f21 (sub open (func))) (type $f22 (sub open $f11 (func))))
     (func $f (type $f21))
     (global (ref $f11) (ref.func $f))
   )
@@ -227,9 +227,9 @@
 ;; Runtime types
 
 (module
-  (type $t0 (sub (func (result (ref null func)))))
-  (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
-  (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+  (type $t0 (sub open (func (result (ref null func)))))
+  (rec (type $t1 (sub open $t0 (func (result (ref null $t1))))))
+  (rec (type $t2 (sub open $t1 (func (result (ref null $t2))))))
 
   (func $f0 (type $t0) (ref.null func))
   (func $f1 (type $t1) (ref.null $t1))
@@ -288,8 +288,8 @@
 (assert_trap (invoke "fail6") "cast")
 
 (module
-  (type $t1 (sub (func)))
-  (type $t2 (sub final (func)))
+  (type $t1 (sub open (func)))
+  (type $t2 (sub (func)))
 
   (func $f1 (type $t1))
   (func $f2 (type $t2))
@@ -318,10 +318,10 @@
 
 
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
-  (rec (type $g1 (sub $f1 (func))) (type (struct)))
-  (rec (type $g2 (sub $f2 (func))) (type (struct)))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g1 (sub open $f1 (func))) (type (struct)))
+  (rec (type $g2 (sub open $f2 (func))) (type (struct)))
   (func $g (type $g2)) (elem declare func $g)
   (func (export "run") (result i32)
     (ref.test (ref $g1) (ref.func $g))
@@ -330,15 +330,15 @@
 (assert_return (invoke "run") (i32.const 1))
 
 (module
-  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
-  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec (type $f1 (sub open (func))) (type $s1 (sub open (struct (field (ref $f1))))))
+  (rec (type $f2 (sub open (func))) (type $s2 (sub open (struct (field (ref $f2))))))
   (rec
-    (type $g1 (sub $f1 (func)))
-    (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
+    (type $g1 (sub open $f1 (func)))
+    (type (sub open $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
   )
   (rec
-    (type $g2 (sub $f2 (func)))
-    (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
+    (type $g2 (sub open $f2 (func)))
+    (type (sub open $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
   )
   (func $g (type $g2)) (elem declare func $g)
   (func (export "run") (result i32)
@@ -348,10 +348,10 @@
 (assert_return (invoke "run") (i32.const 1))
 
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $g1 (sub $f1 (func))) (type (struct)))
-  (rec (type $g2 (sub $f2 (func))) (type (struct)))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $g1 (sub open $f1 (func))) (type (struct)))
+  (rec (type $g2 (sub open $f2 (func))) (type (struct)))
   (func $g (type $g2)) (elem declare func $g)
   (func (export "run") (result i32)
     (ref.test (ref $g1) (ref.func $g))
@@ -360,9 +360,9 @@
 (assert_return (invoke "run") (i32.const 0))
 
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
-  (rec (type $g (sub $f1 (func))) (type (struct)))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g (sub open $f1 (func))) (type (struct)))
   (func $g (type $g)) (elem declare func $g)
   (func (export "run") (result i32)
     (ref.test (ref $f1) (ref.func $g))
@@ -371,17 +371,17 @@
 (assert_return (invoke "run") (i32.const 1))
 
 (module
-  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
-  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec (type $f1 (sub open (func))) (type $s1 (sub open (struct (field (ref $f1))))))
+  (rec (type $f2 (sub open (func))) (type $s2 (sub open (struct (field (ref $f2))))))
   (rec
-    (type $g1 (sub $f1 (func)))
-    (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
+    (type $g1 (sub open $f1 (func)))
+    (type (sub open $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
   )
   (rec
-    (type $g2 (sub $f2 (func)))
-    (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
+    (type $g2 (sub open $f2 (func)))
+    (type (sub open $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
   )
-  (rec (type $h (sub $g2 (func))) (type (struct)))
+  (rec (type $h (sub open $g2 (func))) (type (struct)))
   (func $h (type $h)) (elem declare func $h)
   (func (export "run") (result i32 i32)
     (ref.test (ref $f1) (ref.func $h))
@@ -392,8 +392,8 @@
 
 
 (module
-  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
-  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
+  (rec (type $f11 (sub open (func (result (ref func))))) (type $f12 (sub open $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub open (func (result (ref func))))) (type $f22 (sub open $f21 (func (result (ref $f21))))))
   (func $f11 (type $f11) (unreachable)) (elem declare func $f11)
   (func $f12 (type $f12) (unreachable)) (elem declare func $f12)
   (func (export "run") (result i32 i32 i32 i32)
@@ -408,10 +408,10 @@
 )
 
 (module
-  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
-  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
-  (rec (type $g11 (sub $f11 (func (result (ref func))))) (type $g12 (sub $g11 (func (result (ref $g11))))))
-  (rec (type $g21 (sub $f21 (func (result (ref func))))) (type $g22 (sub $g21 (func (result (ref $g21))))))
+  (rec (type $f11 (sub open (func (result (ref func))))) (type $f12 (sub open $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub open (func (result (ref func))))) (type $f22 (sub open $f21 (func (result (ref $f21))))))
+  (rec (type $g11 (sub open $f11 (func (result (ref func))))) (type $g12 (sub open $g11 (func (result (ref $g11))))))
+  (rec (type $g21 (sub open $f21 (func (result (ref func))))) (type $g22 (sub open $g21 (func (result (ref $g21))))))
   (func $g11 (type $g11) (unreachable)) (elem declare func $g11)
   (func $g12 (type $g12) (unreachable)) (elem declare func $g12)
   (func (export "run") (result i32 i32 i32 i32 i32 i32 i32 i32)
@@ -431,8 +431,8 @@
 )
 
 (module
-  (rec (type $f11 (sub (func))) (type $f12 (sub $f11 (func))))
-  (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+  (rec (type $f11 (sub open (func))) (type $f12 (sub open $f11 (func))))
+  (rec (type $f21 (sub open (func))) (type $f22 (sub open $f11 (func))))
   (func $f (type $f21)) (elem declare func $f)
   (func (export "run") (result i32)
     (ref.test (ref $f11) (ref.func $f))
@@ -441,9 +441,9 @@
 (assert_return (invoke "run") (i32.const 0))
 
 (module
-  (rec (type $f01 (sub (func))) (type $f02 (sub $f01 (func))))
-  (rec (type $f11 (sub (func))) (type $f12 (sub $f01 (func))))
-  (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+  (rec (type $f01 (sub open (func))) (type $f02 (sub open $f01 (func))))
+  (rec (type $f11 (sub open (func))) (type $f12 (sub open $f01 (func))))
+  (rec (type $f21 (sub open (func))) (type $f22 (sub open $f11 (func))))
   (func $f (type $f21)) (elem declare func $f)
   (func (export "run") (result i32)
     (ref.test (ref $f11) (ref.func $f))
@@ -456,9 +456,9 @@
 ;; Linking
 
 (module
-  (type $t0 (sub (func (result (ref null func)))))
-  (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
-  (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+  (type $t0 (sub open (func (result (ref null func)))))
+  (rec (type $t1 (sub open $t0 (func (result (ref null $t1))))))
+  (rec (type $t2 (sub open $t1 (func (result (ref null $t2))))))
 
   (func (export "f0") (type $t0) (ref.null func))
   (func (export "f1") (type $t1) (ref.null $t1))
@@ -467,9 +467,9 @@
 (register "M")
 
 (module
-  (type $t0 (sub (func (result (ref null func)))))
-  (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
-  (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+  (type $t0 (sub open (func (result (ref null func)))))
+  (rec (type $t1 (sub open $t0 (func (result (ref null $t1))))))
+  (rec (type $t2 (sub open $t1 (func (result (ref null $t2))))))
 
   (func (import "M" "f0") (type $t0))
   (func (import "M" "f1") (type $t0))
@@ -481,9 +481,9 @@
 
 (assert_unlinkable
   (module
-    (type $t0 (sub (func (result (ref null func)))))
-    (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
-    (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+    (type $t0 (sub open (func (result (ref null func)))))
+    (rec (type $t1 (sub open $t0 (func (result (ref null $t1))))))
+    (rec (type $t2 (sub open $t1 (func (result (ref null $t2))))))
     (func (import "M" "f0") (type $t1))
   )
   "incompatible import type"
@@ -491,9 +491,9 @@
 
 (assert_unlinkable
   (module
-    (type $t0 (sub (func (result (ref null func)))))
-    (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
-    (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+    (type $t0 (sub open (func (result (ref null func)))))
+    (rec (type $t1 (sub open $t0 (func (result (ref null $t1))))))
+    (rec (type $t2 (sub open $t1 (func (result (ref null $t2))))))
     (func (import "M" "f0") (type $t2))
   )
   "incompatible import type"
@@ -501,17 +501,17 @@
 
 (assert_unlinkable
   (module
-    (type $t0 (sub (func (result (ref null func)))))
-    (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
-    (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+    (type $t0 (sub open (func (result (ref null func)))))
+    (rec (type $t1 (sub open $t0 (func (result (ref null $t1))))))
+    (rec (type $t2 (sub open $t1 (func (result (ref null $t2))))))
     (func (import "M" "f1") (type $t2))
   )
   "incompatible import type"
 )
 
 (module
-  (type $t1 (sub (func)))
-  (type $t2 (sub final (func)))
+  (type $t1 (sub open (func)))
+  (type $t2 (sub (func)))
   (func (export "f1") (type $t1))
   (func (export "f2") (type $t2))
 )
@@ -519,16 +519,16 @@
 
 (assert_unlinkable
   (module
-    (type $t1 (sub (func)))
-    (type $t2 (sub final (func)))
+    (type $t1 (sub open (func)))
+    (type $t2 (sub (func)))
     (func (import "M2" "f1") (type $t2))
   )
   "incompatible import type"
 )
 (assert_unlinkable
   (module
-    (type $t1 (sub (func)))
-    (type $t2 (sub final (func)))
+    (type $t1 (sub open (func)))
+    (type $t2 (sub (func)))
     (func (import "M2" "f2") (type $t1))
   )
   "incompatible import type"
@@ -536,101 +536,101 @@
 
 
 (module
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
-  (rec (type $g2 (sub $f2 (func))) (type (struct)))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g2 (sub open $f2 (func))) (type (struct)))
   (func (export "g") (type $g2))
 )
 (register "M")
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $g1 (sub $f1 (func))) (type (struct)))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $g1 (sub open $f1 (func))) (type (struct)))
   (func (import "M" "g") (type $g1))
 )
 
 (module
-  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
-  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec (type $f1 (sub open (func))) (type $s1 (sub open (struct (field (ref $f1))))))
+  (rec (type $f2 (sub open (func))) (type $s2 (sub open (struct (field (ref $f2))))))
   (rec
-    (type $g2 (sub $f2 (func)))
-    (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
+    (type $g2 (sub open $f2 (func)))
+    (type (sub open $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
   )
   (func (export "g") (type $g2))
 )
 (register "M")
 (module
-  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
-  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec (type $f1 (sub open (func))) (type $s1 (sub open (struct (field (ref $f1))))))
+  (rec (type $f2 (sub open (func))) (type $s2 (sub open (struct (field (ref $f2))))))
   (rec
-    (type $g1 (sub $f1 (func)))
-    (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
+    (type $g1 (sub open $f1 (func)))
+    (type (sub open $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
   )
   (func (import "M" "g") (type $g1))
 )
 
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $g2 (sub $f2 (func))) (type (struct)))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $g2 (sub open $f2 (func))) (type (struct)))
   (func (export "g") (type $g2))
 )
 (register "M")
 (assert_unlinkable
   (module
-    (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-    (rec (type $g1 (sub $f1 (func))) (type (struct)))
+    (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+    (rec (type $g1 (sub open $f1 (func))) (type (struct)))
     (func (import "M" "g") (type $g1))
   )
   "incompatible import"
 )
 
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
-  (rec (type $g (sub $f1 (func))) (type (struct)))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g (sub open $f1 (func))) (type (struct)))
   (func (export "g") (type $g))
 )
 (register "M")
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
-  (rec (type $g (sub $f1 (func))) (type (struct)))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g (sub open $f1 (func))) (type (struct)))
   (func (import "M" "g") (type $f1))
 )
 
 (module
-  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
-  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec (type $f1 (sub open (func))) (type $s1 (sub open (struct (field (ref $f1))))))
+  (rec (type $f2 (sub open (func))) (type $s2 (sub open (struct (field (ref $f2))))))
   (rec
-    (type $g2 (sub $f2 (func)))
-    (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
+    (type $g2 (sub open $f2 (func)))
+    (type (sub open $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
   )
-  (rec (type $h (sub $g2 (func))) (type (struct)))
+  (rec (type $h (sub open $g2 (func))) (type (struct)))
   (func (export "h") (type $h))
 )
 (register "M")
 (module
-  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
-  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec (type $f1 (sub open (func))) (type $s1 (sub open (struct (field (ref $f1))))))
+  (rec (type $f2 (sub open (func))) (type $s2 (sub open (struct (field (ref $f2))))))
   (rec
-    (type $g1 (sub $f1 (func)))
-    (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
+    (type $g1 (sub open $f1 (func)))
+    (type (sub open $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
   )
-  (rec (type $h (sub $g1 (func))) (type (struct)))
+  (rec (type $h (sub open $g1 (func))) (type (struct)))
   (func (import "M" "h") (type $f1))
   (func (import "M" "h") (type $g1))
 )
 
 
 (module
-  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
-  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
+  (rec (type $f11 (sub open (func (result (ref func))))) (type $f12 (sub open $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub open (func (result (ref func))))) (type $f22 (sub open $f21 (func (result (ref $f21))))))
   (func (export "f11") (type $f11) (unreachable))
   (func (export "f12") (type $f12) (unreachable))
 )
 (register "M")
 (module
-  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
-  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
+  (rec (type $f11 (sub open (func (result (ref func))))) (type $f12 (sub open $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub open (func (result (ref func))))) (type $f22 (sub open $f21 (func (result (ref $f21))))))
   (func (import "M" "f11") (type $f11))
   (func (import "M" "f11") (type $f21))
   (func (import "M" "f12") (type $f12))
@@ -638,19 +638,19 @@
 )
 
 (module
-  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
-  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
-  (rec (type $g11 (sub $f11 (func (result (ref func))))) (type $g12 (sub $g11 (func (result (ref $g11))))))
-  (rec (type $g21 (sub $f21 (func (result (ref func))))) (type $g22 (sub $g21 (func (result (ref $g21))))))
+  (rec (type $f11 (sub open (func (result (ref func))))) (type $f12 (sub open $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub open (func (result (ref func))))) (type $f22 (sub open $f21 (func (result (ref $f21))))))
+  (rec (type $g11 (sub open $f11 (func (result (ref func))))) (type $g12 (sub open $g11 (func (result (ref $g11))))))
+  (rec (type $g21 (sub open $f21 (func (result (ref func))))) (type $g22 (sub open $g21 (func (result (ref $g21))))))
   (func (export "g11") (type $g11) (unreachable))
   (func (export "g12") (type $g12) (unreachable))
 )
 (register "M")
 (module
-  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
-  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
-  (rec (type $g11 (sub $f11 (func (result (ref func))))) (type $g12 (sub $g11 (func (result (ref $g11))))))
-  (rec (type $g21 (sub $f21 (func (result (ref func))))) (type $g22 (sub $g21 (func (result (ref $g21))))))
+  (rec (type $f11 (sub open (func (result (ref func))))) (type $f12 (sub open $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub open (func (result (ref func))))) (type $f22 (sub open $f21 (func (result (ref $f21))))))
+  (rec (type $g11 (sub open $f11 (func (result (ref func))))) (type $g12 (sub open $g11 (func (result (ref $g11))))))
+  (rec (type $g21 (sub open $f21 (func (result (ref func))))) (type $g22 (sub open $g21 (func (result (ref $g21))))))
   (func (import "M" "g11") (type $f11))
   (func (import "M" "g11") (type $f21))
   (func (import "M" "g12") (type $f11))
@@ -662,30 +662,30 @@
 )
 
 (module
-  (rec (type $f11 (sub (func))) (type $f12 (sub $f11 (func))))
-  (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+  (rec (type $f11 (sub open (func))) (type $f12 (sub open $f11 (func))))
+  (rec (type $f21 (sub open (func))) (type $f22 (sub open $f11 (func))))
   (func (export "f") (type $f21))
 )
 (register "M")
 (assert_unlinkable
   (module
-    (rec (type $f11 (sub (func))) (type $f12 (sub $f11 (func))))
+    (rec (type $f11 (sub open (func))) (type $f12 (sub open $f11 (func))))
     (func (import "M" "f") (type $f11))
   )
   "incompatible import"
 )
 
 (module
-  (rec (type $f01 (sub (func))) (type $f02 (sub $f01 (func))))
-  (rec (type $f11 (sub (func))) (type $f12 (sub $f01 (func))))
-  (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+  (rec (type $f01 (sub open (func))) (type $f02 (sub open $f01 (func))))
+  (rec (type $f11 (sub open (func))) (type $f12 (sub open $f01 (func))))
+  (rec (type $f21 (sub open (func))) (type $f22 (sub open $f11 (func))))
   (func (export "f") (type $f21))
 )
 (register "M")
 (assert_unlinkable
   (module
-    (rec (type $f01 (sub (func))) (type $f02 (sub $f01 (func))))
-    (rec (type $f11 (sub (func))) (type $f12 (sub $f01 (func))))
+    (rec (type $f01 (sub open (func))) (type $f02 (sub open $f01 (func))))
+    (rec (type $f11 (sub open (func))) (type $f12 (sub open $f01 (func))))
     (func (import "M" "f") (type $f11))
   )
   "incompatible import"
@@ -713,7 +713,7 @@
 
 (assert_invalid
   (module
-    (type $t (sub final (func)))
+    (type $t (sub (func)))
     (type $s (sub $t (func)))
   )
   "sub type"
@@ -722,8 +722,8 @@
 (assert_invalid
   (module
     (type $t (sub (func)))
-    (type $s (sub final $t (func)))
-    (type $u (sub $s (func)))
+    (type $s (sub $t (func)))
+    (type $u (sub open $s (func)))
   )
   "sub type"
 )
@@ -734,15 +734,15 @@
 
 (assert_invalid
   (module
-    (type $a0 (sub (array i32)))
+    (type $a0 (sub open (array i32)))
     (type $s0 (sub $a0 (struct)))
   )
   "sub type"
 )
 
-(assert_invalid 
+(assert_invalid
   (module
-    (type $f0 (sub (func (param i32) (result i32))))
+    (type $f0 (sub open (func (param i32) (result i32))))
     (type $s0 (sub $f0 (struct)))
   )
   "sub type"
@@ -750,7 +750,7 @@
 
 (assert_invalid
   (module
-    (type $s0 (sub (struct)))
+    (type $s0 (sub open (struct)))
     (type $a0 (sub $s0 (array i32)))
   )
   "sub type"
@@ -758,23 +758,23 @@
 
 (assert_invalid
   (module
-    (type $f0 (sub (func (param i32) (result i32))))
+    (type $f0 (sub open (func (param i32) (result i32))))
     (type $a0 (sub $f0 (array i32)))
   )
   "sub type"
 )
 
-(assert_invalid 
+(assert_invalid
   (module
-    (type $s0 (sub (struct)))
+    (type $s0 (sub open (struct)))
     (type $f0 (sub $s0 (func (param i32) (result i32))))
   )
   "sub type"
 )
 
-(assert_invalid 
+(assert_invalid
   (module
-    (type $a0 (sub (array i32)))
+    (type $a0 (sub open (array i32)))
     (type $f0 (sub $a0 (func (param i32) (result i32))))
   )
   "sub type"
@@ -782,7 +782,7 @@
 
 (assert_invalid
   (module
-    (type $a0 (sub (array i32)))
+    (type $a0 (sub open (array i32)))
     (type $a1 (sub $a0 (array i64)))
   )
   "sub type"
@@ -790,7 +790,7 @@
 
 (assert_invalid
   (module
-    (type $s0 (sub (struct (field i32))))
+    (type $s0 (sub open (struct (field i32))))
     (type $s1 (sub $s0 (struct (field i64))))
   )
   "sub type"
@@ -798,7 +798,7 @@
 
 (assert_invalid
   (module
-    (type $f0 (sub (func)))
+    (type $f0 (sub open (func)))
     (type $f1 (sub $f0 (func (param i32))))
   )
   "sub type"


### PR DESCRIPTION
Addresses discussion from #333. With this patch, the keyword `final` in subtypes has been replaced with the keyword `open`:

```
(type $s1 (sub (struct)))                       ;; final with no super types
(type $s2 (sub open (struct)))                  ;; non-final with no super types
(type $s3 (sub $s2 (struct (field i32))))       ;; final with one super type
(type $s4 (sub open $s2 (struct (field i32))))  ;; non-final with one super type

(type $s5 (struct))                             ;; equivalent to $s1 (final)
```

This avoids a confusing flip-flopping behavior where a seemingly-unnecessary empty `sub` was commonly used to make types non-final. An empty `sub` is now equivalent to no `sub`, making the abbreviation more obvious.

This patch is currently quite minimal, and only modifies enough of the spec and interpreter to support `open` in the text format. The word `final` is otherwise used throughout the spec and interpreter. If we would rather use the word `open` everywhere, I'd be happy to update the rest of the spec and interpreter to match.