### PR TITLE
Updated packed type encodings in the spec and interpreter

### DIFF
--- a/document/core/appendix/index-types.rst
+++ b/document/core/appendix/index-types.rst
@@ -13,8 +13,9 @@ Category                                  Constructor                           
 :ref:`Number type <syntax-numtype>`       |F32|                                               :math:`\hex{7D}` (-3 as |Bs7|)
 :ref:`Number type <syntax-numtype>`       |F64|                                               :math:`\hex{7C}` (-4 as |Bs7|)
 :ref:`Vector type <syntax-vectype>`       |V128|                                              :math:`\hex{7B}` (-5 as |Bs7|)
-:ref:`Packed type <syntax-packedtype>`    |I8|                                                :math:`\hex{7A}` (-6 as |Bs7|)
-:ref:`Packed type <syntax-packedtype>`    |I16|                                               :math:`\hex{79}` (-7 as |Bs7|)
+(reserved)                                                                                    :math:`\hex{7a}` .. :math:`\hex{79}`
+:ref:`Packed type <syntax-packedtype>`    |I8|                                                :math:`\hex{78}` (-8 as |Bs7|)
+:ref:`Packed type <syntax-packedtype>`    |I16|                                               :math:`\hex{77}` (-9 as |Bs7|)
 (reserved)                                                                                    :math:`\hex{78}` .. :math:`\hex{74}`
 :ref:`Heap type <syntax-heaptype>`        |NOFUNC|                                            :math:`\hex{73}` (-13 as |Bs7|)
 :ref:`Heap type <syntax-heaptype>`        |NOEXTERN|                                          :math:`\hex{72}` (-14 as |Bs7|)

--- a/document/core/binary/types.rst
+++ b/document/core/binary/types.rst
@@ -185,9 +185,9 @@ Aggregate Types
      t{:}\Bpackedtype
        &\Rightarrow& t \\
    \production{packed type} & \Bpackedtype &::=&
-     \hex{7A}
+     \hex{78}
        &\Rightarrow& \I8 \\ &&|&
-     \hex{79}
+     \hex{77}
        &\Rightarrow& \I16 \\
    \end{array}
 

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -220,8 +220,8 @@ let result_type s = vec val_type s
 let pack_type s =
   let pos = pos s in
   match s7 s with
-  | -0x06 -> Pack.Pack8
-  | -0x07 -> Pack.Pack16
+  | -0x08 -> Pack.Pack8
+  | -0x09 -> Pack.Pack16
   | _ -> error s pos "malformed storage type"
 
 let storage_type s =

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -153,8 +153,8 @@ struct
     | BotT -> assert false
 
   let pack_type = function
-    | Pack.Pack8 -> s7 (-0x06)
-    | Pack.Pack16 -> s7 (-0x07)
+    | Pack.Pack8 -> s7 (-0x08)
+    | Pack.Pack16 -> s7 (-0x09)
     | Pack.Pack32 | Pack.Pack64 -> assert false
 
   let storage_type = function

--- a/test/core/gc/binary-gc.wast
+++ b/test/core/gc/binary-gc.wast
@@ -5,7 +5,7 @@
     "\05"                     ;; Type section length
     "\01"                     ;; Types vector length
     "\5e"                     ;; Array type, -0x22
-    "\7a"                     ;; Storage type: i8 or -0x06
+    "\78"                     ;; Storage type: i8 or -0x08
     "\02"                     ;; Mutability, should be 0 or 1, but isn't
   )
   "malformed mutability"


### PR DESCRIPTION
This was missed in #372.