### PR TITLE
Add `(sub open ...)` and make it mandatory

### DIFF
--- a/document/core/appendix/algorithm.rst
+++ b/document/core/appendix/algorithm.rst
@@ -57,8 +57,9 @@ Similarly, :ref:`defined types <syntax-deftype>` :code:`def_type` can be represe
    type array_type = Array(fields : field_type)
    type func_type = Func(params : list(val_type), results : list(val_type))
    type comp_type = struct_type | array_type | func_type
+   type ext_type = Open | Final
 
-   type sub_type = Sub(super : list(def_type), body : comp_type, final : bool)
+   type sub_type = Sub(super : list(def_type), body : comp_type, ext : ext_type)
    type rec_type = Rec(types : list(sub_type))
 
    type def_type = Def(rec : rec_type, proj : int32)

--- a/document/core/appendix/index-types.rst
+++ b/document/core/appendix/index-types.rst
@@ -35,7 +35,7 @@ Category                                  Constructor                           
 :ref:`Composite type <syntax-comptype>`   :math:`\TSTRUCT~\fieldtype^\ast`                    :math:`\hex{5F}` (-33 as |Bs7|)
 :ref:`Composite type <syntax-comptype>`   :math:`\TARRAY~\fieldtype`                          :math:`\hex{5E}` (-34 as |Bs7|)
 (reserved)                                                                                    :math:`\hex{5D}` .. :math:`\hex{51}`
-:ref:`Sub type <syntax-subtype>`          :math:`\TSUB~\typeidx^\ast~\comptype`               :math:`\hex{50}` (-48 as |Bs7|)
+:ref:`Sub type <syntax-subtype>`          :math:`\TSUB~\TOPEN~\typeidx^\ast~\comptype`               :math:`\hex{50}` (-48 as |Bs7|)
 :ref:`Sub type <syntax-subtype>`          :math:`\TSUB~\TFINAL~\typeidx^\ast~\comptype`       :math:`\hex{4F}` (-49 as |Bs7|)
 :ref:`Recursive type <syntax-rectype>`    :math:`\TREC~\subtype^\ast`                         :math:`\hex{4E}` (-50 as |Bs7|)
 (reserved)                                                                                    :math:`\hex{4D}` .. :math:`\hex{41}`

--- a/document/core/binary/types.rst
+++ b/document/core/binary/types.rst
@@ -223,7 +223,7 @@ Recursive Types
 ~~~~~~~~~~~~~~~
 
 :ref:`Recursive types <syntax-rectype>` are encoded by the byte :math:`\hex{31}` followed by a :ref:`vector <binary-vec>` of :ref:`sub types <syntax-subtype>`.
-Additional shorthands are recognized for unary recursions and sub types without super types.
+Additional shorthands are recognized for unary recursions and final sub types without super types.
 
 .. math::
    \begin{array}{llclll@{\qquad\qquad}l}
@@ -234,7 +234,7 @@ Additional shorthands are recognized for unary recursions and sub types without 
        &\Rightarrow& \TREC~\X{st} \\
    \production{sub type} & \Bsubtype &::=&
      \hex{50}~~x^\ast{:\,}\Bvec(\Btypeidx)~~\X{ct}{:}\Bcomptype
-       &\Rightarrow& \TSUB~x^\ast~\X{ct} \\ &&|&
+       &\Rightarrow& \TSUB~\TOPEN~x^\ast~\X{ct} \\ &&|&
      \hex{4E}~~x^\ast{:\,}\Bvec(\Btypeidx)~~\X{ct}{:}\Bcomptype
        &\Rightarrow& \TSUB~\TFINAL~x^\ast~\X{ct} \\ &&|&
      \X{ct}{:}\Bcomptype

--- a/document/core/syntax/types.rst
+++ b/document/core/syntax/types.rst
@@ -291,25 +291,27 @@ including :ref:`function types <syntax-functype>` and :ref:`aggregate types <syn
    \end{array}
 
 
-.. index:: ! recursive type, ! sub type, composite type, ! final, subtyping, ! roll, ! unroll, recursive type index
+.. index:: ! recursive type, ! sub type, composite type, ! open, ! final, subtyping, ! roll, ! unroll, recursive type index
    pair: abstract syntax; recursive type
    pair: abstract syntax; sub type
 .. _syntax-rectype:
 .. _syntax-subtype:
+.. _syntax-ext:
 
 Recursive Types
 ~~~~~~~~~~~~~~~
 
 *Recursive types* denote a group of mutually recursive :ref:`composite types <syntax-comptype>`, each of which can optionally declare a list of :ref:`type indices <syntax-typeidx>` of supertypes that it :ref:`matches <match-comptype>`.
-Each type can also be declared *final*, preventing further subtyping.
-.
+Each type can also be declared *open*, in which case they may have further subtypes, or *final*, preventing further subtyping.
 
 .. math::
    \begin{array}{llrl}
    \production{recursive type} & \rectype &::=&
      \TREC~\subtype^\ast \\
    \production{sub types} & \subtype &::=&
-     \TSUB~\TFINAL^?~\typeidx^\ast~\comptype \\
+     \TSUB~\ext~\typeidx^\ast~\comptype \\
+   \production{extension type} & \ext &::=&
+     \TOPEN ~|~ \TFINAL \\
    \end{array}
 
 In a :ref:`module <syntax-module>`, each member of a recursive type is assigned a separate :ref:`type index <syntax-typeidx>`.

--- a/document/core/text/types.rst
+++ b/document/core/text/types.rst
@@ -242,6 +242,7 @@ Composite Types
 .. _text-rectype:
 .. _text-subtype:
 .. _text-deftype:
+.. _text-exttype:
 
 Recursive Types
 ~~~~~~~~~~~~~~~
@@ -255,8 +256,11 @@ Recursive Types
      \text{(}~\text{type}~~\Tid^?~~\X{st}{:}\Tsubtype_I~\text{)}
        &\Rightarrow& \X{st} \\
    \production{sub type} & \Tsubtype_I &::=&
-     \text{(}~\text{sub}~~\text{final}^?~~x^\ast{:\,}\Tvec(\Ttypeidx_I)~~\X{ct}{:}\Tcomptype_I~\text{)}
-       &\Rightarrow& \TSUB~\TFINAL^?~x^\ast~\X{ct} \\
+     \text{(}~\text{sub}~~\X{ext}{:}\Texttype~~x^\ast{:\,}\Tvec(\Ttypeidx_I)~~\X{ct}{:}\Tcomptype_I~\text{)}
+       &\Rightarrow& \TSUB~\X{ext}~x^\ast~\X{ct} \\
+   \production{extension type} & \Texttype &::=&
+     \text{open} &\Rightarrow& \TOPEN \\ &&|&
+     \text{final} &\Rightarrow& \TFINAL \\
    \end{array}
 
 

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -234,6 +234,7 @@
 .. |TARRAY| mathdef:: \xref{syntax/types}{syntax-comptype}{\K{array}}
 .. |TSUB| mathdef:: \xref{syntax/types}{syntax-subtype}{\K{sub}}
 .. |TREC| mathdef:: \xref{syntax/types}{syntax-rectype}{\K{rec}}
+.. |TOPEN| mathdef:: \xref{syntax/types}{syntax-subtype}{\K{open}}
 .. |TFINAL| mathdef:: \xref{syntax/types}{syntax-subtype}{\K{final}}
 
 .. |MVAR| mathdef:: \xref{syntax/types}{syntax-mut}{\K{var}}
@@ -270,6 +271,7 @@
 .. |subtype| mathdef:: \xref{syntax/types}{syntax-subtype}{\X{subtype}}
 .. |rectype| mathdef:: \xref{syntax/types}{syntax-rectype}{\X{rectype}}
 .. |deftype| mathdef:: \xref{valid/conventions}{syntax-deftype}{\X{deftype}}
+.. |ext| mathdef:: \xref{syntax/types}{syntax-ext}{\X{ext}}
 
 .. |globaltype| mathdef:: \xref{syntax/types}{syntax-globaltype}{\X{globaltype}}
 .. |tabletype| mathdef:: \xref{syntax/types}{syntax-tabletype}{\X{tabletype}}
@@ -906,6 +908,7 @@
 .. |Tstoragetype| mathdef:: \xref{text/types}{text-storagetype}{\T{storagetype}}
 .. |Tpackedtype| mathdef:: \xref{text/types}{text-packedtype}{\T{packedtype}}
 .. |Tcomptype| mathdef:: \xref{text/types}{text-comptype}{\T{comptype}}
+.. |Texttype| mathdef:: \xref{text/types}{text-exttype}{\T{exttype}}
 .. |Tsubtype| mathdef:: \xref{text/types}{text-subtype}{\T{subtype}}
 .. |Tdeftype| mathdef:: \xref{text/types}{text-deftype}{\T{deftype}}
 .. |Trectype| mathdef:: \xref{text/types}{text-rectype}{\T{rectype}}

--- a/document/core/valid/conventions.rst
+++ b/document/core/valid/conventions.rst
@@ -52,7 +52,7 @@ they only occur during :ref:`validation <valid>` or :ref:`execution <exec>`.
    \production{heap type} & \heaptype &::=&
      \dots ~|~ \deftype ~|~ \REC~i \\
    \production{sub types} & \subtype &::=&
-     \TSUB~\TFINAL^?~\heaptype^\ast~\comptype \\
+     \TSUB~\ext~\heaptype^\ast~\comptype \\
    \end{array}
 
 The unique :ref:`value type <syntax-valtype>` |BOT| is a *bottom type* that :ref:`matches <match-heaptype>` all value types.
@@ -180,7 +180,7 @@ In addition, the following auxiliary function denotes the *expansion* of a :ref:
 
 .. math::
    \begin{array}{@{}llll@{}}
-   \expanddt(\deftype) &=& \comptype & (\iff \unrolldt(\deftype) = \TSUB~\TFINAL^?~\X{ht}^?~\comptype) \\
+   \expanddt(\deftype) &=& \comptype & (\iff \unrolldt(\deftype) = \TSUB~\ext~\X{ht}^?~\comptype) \\
    \end{array}
 
 

--- a/document/core/valid/matching.rst
+++ b/document/core/valid/matching.rst
@@ -431,7 +431,7 @@ A :ref:`defined type <syntax-deftype>` :math:`\deftype_1` matches a type :math:`
 
 * Or:
 
-  * Let the :ref:`sub type <syntax-subtype>` :math:`\TSUB~\TFINAL^?~\heaptype^\ast~\comptype` be the result of :ref:`unrolling <aux-unroll-deftype>` :math:`\deftype_1`.
+  * Let the :ref:`sub type <syntax-subtype>` :math:`\TSUB~\ext~\heaptype^\ast~\comptype` be the result of :ref:`unrolling <aux-unroll-deftype>` :math:`\deftype_1`.
 
   * Then there must exist a :ref:`heap type <syntax-heaptype>` :math:`\heaptype_i` in :math:`\heaptype^\ast` that :ref:`matches <match-heaptype>` :math:`\deftype_2`.
 
@@ -446,7 +446,7 @@ A :ref:`defined type <syntax-deftype>` :math:`\deftype_1` matches a type :math:`
 .. math::
    ~\\[-1ex]
    \frac{
-     \unrolldt(\deftype_1) = \TSUB~\TFINAL^?~\heaptype^\ast~\comptype
+     \unrolldt(\deftype_1) = \TSUB~\ext~\heaptype^\ast~\comptype
      \qquad
      C \vdashheaptypematch \heaptype^\ast[i] \matchesheaptype \deftype_2
    }{

--- a/document/core/valid/types.rst
+++ b/document/core/valid/types.rst
@@ -405,7 +405,7 @@ Recursive Types
      C \vdashrectype \TREC~\subtype~{\subtype'}^\ast ~{\ok}(x)
    }
 
-:math:`\TSUB~\TFINAL^?~y^\ast~\comptype`
+:math:`\TSUB~\ext~y^\ast~\comptype`
 ........................................
 
 * The :ref:`composite type <syntax-comptype>` :math:`\comptype` must be :ref:`valid <valid-comptype>`.
@@ -420,7 +420,7 @@ Recursive Types
 
   * Let :math:`\subtype_i` be the :ref:`unrolling <aux-unroll-deftype>` of the :ref:`defined type <syntax-deftype>` :math:`C.\CTYPES[y_i]`.
 
-  * The :ref:`sub type <syntax-subtype>` :math:`\subtype_i` must not contain :math:`\TFINAL`.
+  * The :ref:`sub type <syntax-subtype>` :math:`\subtype_i` must contain :math:`\TOPEN`.
 
   * Let :math:`\comptype'_i` be the :ref:`expansion <aux-expand-deftype>` of the :ref:`defined type <syntax-deftype>` :math:`C.\CTYPES[y_i]`.
 
@@ -435,14 +435,14 @@ Recursive Types
      \qquad
      (y < x)^\ast
      \qquad
-     (\unrolldt(C.\CTYPES[y]) = \TSUB~{y'}^\ast~\comptype')^\ast
+     (\unrolldt(C.\CTYPES[y]) = \TSUB~\TOPEN~{y'}^\ast~\comptype')^\ast
      \\
      C \vdashcomptype \comptype \ok
      \qquad
      (C \vdashcomptypematch \comptype \matchescomptype \comptype')^\ast
      \end{array}
    }{
-     C \vdashsubtype \TSUB~\TFINAL^?~y^\ast~\comptype ~{\ok}(x)
+     C \vdashsubtype \TSUB~\ext~y^\ast~\comptype ~{\ok}(x)
    }
 
 .. note::

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -258,7 +258,7 @@ let sub_type s =
   | Some i when i = -0x30 land 0x7f ->
     skip 1 s;
     let xs = vec (var_type u32) s in
-    SubT (NoFinal, List.map (fun x -> VarHT x) xs, str_type s)
+    SubT (Open, List.map (fun x -> VarHT x) xs, str_type s)
   | Some i when i = -0x31 land 0x7f ->
     skip 1 s;
     let xs = vec (var_type u32) s in

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -181,7 +181,7 @@ struct
   let sub_type = function
     | SubT (Final, [], st) -> str_type st
     | SubT (Final, hts, st) -> s7 (-0x31); vec var_heap_type hts; str_type st
-    | SubT (NoFinal, hts, st) -> s7 (-0x30); vec var_heap_type hts; str_type st
+    | SubT (Open, hts, st) -> s7 (-0x30); vec var_heap_type hts; str_type st
 
   let rec_type = function
     | RecT [st] -> sub_type st

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -7,7 +7,7 @@ type name = Utf8.unicode
 type null = NoNull | Null
 type mut = Cons | Var
 type init = Set | Unset
-type final = NoFinal | Final
+type ext = Open | Final
 type 'a limits = {min : 'a; max : 'a option}
 
 type var = StatX of type_idx | RecX of int32
@@ -39,7 +39,7 @@ and str_type =
   | DefArrayT of array_type
   | DefFuncT of func_type
 
-and sub_type = SubT of final * heap_type list * str_type
+and sub_type = SubT of ext * heap_type list * str_type
 and rec_type = RecT of sub_type list
 and def_type = DefT of rec_type * int32
 
@@ -307,9 +307,9 @@ let string_of_null = function
   | NoNull -> ""
   | Null -> "null "
 
-let string_of_final = function
-  | NoFinal -> ""
-  | Final -> " final"
+let string_of_ext = function
+  | Open -> "open"
+  | Final -> "final"
 
 let string_of_mut s = function
   | Cons -> s
@@ -379,9 +379,9 @@ and string_of_str_type = function
 
 and string_of_sub_type = function
   | SubT (Final, [], st) -> string_of_str_type st
-  | SubT (fin, hts, st) ->
+  | SubT (ext, hts, st) ->
     String.concat " "
-      (("sub" ^ string_of_final fin) :: List.map string_of_heap_type hts) ^
+      (("sub " ^ string_of_ext ext) :: List.map string_of_heap_type hts) ^
     " (" ^ string_of_str_type st ^ ")"
 
 and string_of_rec_type = function

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -77,9 +77,9 @@ let heap_type t = string_of_heap_type t
 let val_type t = string_of_val_type t
 let storage_type t = string_of_storage_type t
 
-let final = function
-  | NoFinal -> ""
-  | Final -> " final"
+let extendability = function
+  | Open -> "open"
+  | Final -> "final"
 
 let decls kind ts = tab kind (atom val_type) ts
 
@@ -103,9 +103,9 @@ let str_type st =
 
 let sub_type = function
   | SubT (Final, [], st) -> str_type st
-  | SubT (fin, xs, st) ->
+  | SubT (ext, xs, st) ->
     Node (String.concat " "
-      (("sub" ^ final fin ):: List.map heap_type xs), [str_type st])
+      (("sub " ^ extendability ext):: List.map heap_type xs), [str_type st])
 
 let rec_type i j st =
   Node ("type $" ^ nat (i + j), [sub_type st])

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -82,7 +82,7 @@ let character =
     [^'"''\\''\x00'-'\x1f''\x7f'-'\xff']
   | utf8enc
   | '\\'escape
-  | '\\'hexdigit hexdigit 
+  | '\\'hexdigit hexdigit
   | "\\u{" hexnum '}'
 
 let nat = num | "0x" hexnum
@@ -175,6 +175,7 @@ rule token = parse
       | "field" -> FIELD
       | "mut" -> MUT
       | "sub" -> SUB
+      | "open" -> OPEN
       | "final" -> FINAL
       | "rec" -> REC
 

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -257,7 +257,7 @@ let inline_func_type_explicit (c : context) x ft at =
 %token ANYREF NULLREF EQREF I31REF STRUCTREF ARRAYREF
 %token FUNCREF NULLFUNCREF EXTERNREF NULLEXTERNREF
 %token ANY NONE EQ I31 REF NOFUNC EXTERN NOEXTERN NULL
-%token MUT FIELD STRUCT ARRAY SUB FINAL REC
+%token MUT FIELD STRUCT ARRAY SUB OPEN FINAL REC
 %token UNREACHABLE NOP DROP SELECT
 %token BLOCK END IF THEN ELSE LOOP
 %token BR BR_IF BR_TABLE
@@ -413,9 +413,9 @@ str_type :
 
 sub_type :
   | str_type { fun c x -> SubT (Final, [], $1 c x) }
-  | LPAR SUB var_list str_type RPAR
-    { fun c x -> SubT (NoFinal,
-        List.map (fun y -> VarHT (StatX y.it)) ($3 c type_), $4 c x) }
+  | LPAR SUB OPEN var_list str_type RPAR
+    { fun c x -> SubT (Open,
+        List.map (fun y -> VarHT (StatX y.it)) ($4 c type_), $5 c x) }
   | LPAR SUB FINAL var_list str_type RPAR
     { fun c x -> SubT (Final,
         List.map (fun y -> VarHT (StatX y.it)) ($4 c type_), $5 c x) }

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -174,13 +174,13 @@ let check_sub_type (c : context) (sut : sub_type) at =
   check_str_type c st at
 
 let check_sub_type_sub (c : context) (sut : sub_type) x at =
-  let SubT (_fin, hts, st) = sut in
+  let SubT (_ext, hts, st) = sut in
   List.iter (fun hti ->
     let xi = match hti with VarHT (StatX xi) -> xi | _ -> assert false in
-    let SubT (fini, _, sti) = unroll_def_type (type_ c (xi @@ at)) in
+    let SubT (ext, _, sti) = unroll_def_type (type_ c (xi @@ at)) in
     require (xi < x) at ("forward use of type " ^ I32.to_string_u xi ^
       " in sub type definition");
-    require (fini = NoFinal) at ("sub type " ^ I32.to_string_u x ^
+    require (ext = Open) at ("sub type " ^ I32.to_string_u x ^
       " has final super type " ^ I32.to_string_u xi);
     require (match_str_type c.types st sti) at ("sub type " ^ I32.to_string_u x ^
       " does not match super type " ^ I32.to_string_u xi)

--- a/test/core/gc/br_on_cast.wast
+++ b/test/core/gc/br_on_cast.wast
@@ -102,14 +102,14 @@
 ;; Concrete Types
 
 (module
-  (type $t0 (sub (struct)))
-  (type $t1 (sub $t0 (struct (field i32))))
-  (type $t1' (sub $t0 (struct (field i32))))
-  (type $t2 (sub $t1 (struct (field i32 i32))))
-  (type $t2' (sub $t1' (struct (field i32 i32))))
-  (type $t3 (sub $t0 (struct (field i32 i32))))
-  (type $t0' (sub $t0 (struct)))
-  (type $t4 (sub $t0' (struct (field i32 i32))))
+  (type $t0 (sub open (struct)))
+  (type $t1 (sub open $t0 (struct (field i32))))
+  (type $t1' (sub open $t0 (struct (field i32))))
+  (type $t2 (sub open $t1 (struct (field i32 i32))))
+  (type $t2' (sub open $t1' (struct (field i32 i32))))
+  (type $t3 (sub open $t0 (struct (field i32 i32))))
+  (type $t0' (sub open $t0 (struct)))
+  (type $t4 (sub open $t0' (struct (field i32 i32))))
 
   (table 20 structref)
 

--- a/test/core/gc/br_on_cast_fail.wast
+++ b/test/core/gc/br_on_cast_fail.wast
@@ -102,14 +102,14 @@
 ;; Concrete Types
 
 (module
-  (type $t0 (sub (struct)))
-  (type $t1 (sub $t0 (struct (field i32))))
-  (type $t1' (sub $t0 (struct (field i32))))
-  (type $t2 (sub $t1 (struct (field i32 i32))))
-  (type $t2' (sub $t1' (struct (field i32 i32))))
-  (type $t3 (sub $t0 (struct (field i32 i32))))
-  (type $t0' (sub $t0 (struct)))
-  (type $t4 (sub $t0' (struct (field i32 i32))))
+  (type $t0 (sub open (struct)))
+  (type $t1 (sub open $t0 (struct (field i32))))
+  (type $t1' (sub open $t0 (struct (field i32))))
+  (type $t2 (sub open $t1 (struct (field i32 i32))))
+  (type $t2' (sub open $t1' (struct (field i32 i32))))
+  (type $t3 (sub open $t0 (struct (field i32 i32))))
+  (type $t0' (sub open $t0 (struct)))
+  (type $t4 (sub open $t0' (struct (field i32 i32))))
 
   (table 20 structref)
 

--- a/test/core/gc/ref_cast.wast
+++ b/test/core/gc/ref_cast.wast
@@ -97,14 +97,14 @@
 ;; Concrete Types
 
 (module
-  (type $t0 (sub (struct)))
-  (type $t1 (sub $t0 (struct (field i32))))
-  (type $t1' (sub $t0 (struct (field i32))))
-  (type $t2 (sub $t1 (struct (field i32 i32))))
-  (type $t2' (sub $t1' (struct (field i32 i32))))
-  (type $t3 (sub $t0 (struct (field i32 i32))))
-  (type $t0' (sub $t0 (struct)))
-  (type $t4 (sub $t0' (struct (field i32 i32))))
+  (type $t0 (sub open (struct)))
+  (type $t1 (sub open $t0 (struct (field i32))))
+  (type $t1' (sub open $t0 (struct (field i32))))
+  (type $t2 (sub open $t1 (struct (field i32 i32))))
+  (type $t2' (sub open $t1' (struct (field i32 i32))))
+  (type $t3 (sub open $t0 (struct (field i32 i32))))
+  (type $t0' (sub open $t0 (struct)))
+  (type $t4 (sub open $t0' (struct (field i32 i32))))
 
   (table 20 (ref null struct))
 

--- a/test/core/gc/ref_eq.wast
+++ b/test/core/gc/ref_eq.wast
@@ -1,11 +1,11 @@
 (module
-  (type $st (sub (struct)))
-  (type $st' (sub (struct (field i32))))
+  (type $st (sub open (struct)))
+  (type $st' (sub open (struct (field i32))))
   (type $at (array i8))
-  (type $st-sub1 (sub $st (struct)))
-  (type $st-sub2 (sub $st (struct)))
-  (type $st'-sub1 (sub $st' (struct (field i32))))
-  (type $st'-sub2 (sub $st' (struct (field i32))))
+  (type $st-sub1 (sub open $st (struct)))
+  (type $st-sub2 (sub open $st (struct)))
+  (type $st'-sub1 (sub open $st' (struct (field i32))))
+  (type $st'-sub2 (sub open $st' (struct (field i32))))
 
   (table 20 (ref null eq))
 

--- a/test/core/gc/ref_test.wast
+++ b/test/core/gc/ref_test.wast
@@ -180,14 +180,14 @@
 ;; Concrete Types
 
 (module
-  (type $t0 (sub (struct)))
-  (type $t1 (sub $t0 (struct (field i32))))
-  (type $t1' (sub $t0 (struct (field i32))))
-  (type $t2 (sub $t1 (struct (field i32 i32))))
-  (type $t2' (sub $t1' (struct (field i32 i32))))
-  (type $t3 (sub $t0 (struct (field i32 i32))))
-  (type $t0' (sub $t0 (struct)))
-  (type $t4 (sub $t0' (struct (field i32 i32))))
+  (type $t0 (sub open (struct)))
+  (type $t1 (sub open $t0 (struct (field i32))))
+  (type $t1' (sub open $t0 (struct (field i32))))
+  (type $t2 (sub open $t1 (struct (field i32 i32))))
+  (type $t2' (sub open $t1' (struct (field i32 i32))))
+  (type $t3 (sub open $t0 (struct (field i32 i32))))
+  (type $t0' (sub open $t0 (struct)))
+  (type $t4 (sub open $t0' (struct (field i32 i32))))
 
   (table 20 (ref null struct))
 

--- a/test/core/gc/type-subtyping.wast
+++ b/test/core/gc/type-subtyping.wast
@@ -1,64 +1,64 @@
 ;; Definitions
 
 (module
-  (type $e0 (sub (array i32)))
-  (type $e1 (sub $e0 (array i32)))
+  (type $e0 (sub open (array i32)))
+  (type $e1 (sub open $e0 (array i32)))
 
-  (type $e2 (sub (array anyref)))
-  (type $e3 (sub (array (ref null $e0))))
-  (type $e4 (sub (array (ref $e1))))
+  (type $e2 (sub open (array anyref)))
+  (type $e3 (sub open (array (ref null $e0))))
+  (type $e4 (sub open (array (ref $e1))))
 
-  (type $m1 (sub (array (mut i32))))
-  (type $m2 (sub $m1 (array (mut i32))))
+  (type $m1 (sub open (array (mut i32))))
+  (type $m2 (sub open $m1 (array (mut i32))))
 )
 
 (module
-  (type $e0 (sub (struct)))
-  (type $e1 (sub $e0 (struct)))
-  (type $e2 (sub $e1 (struct (field i32))))
-  (type $e3 (sub $e2 (struct (field i32 (ref null $e0)))))
-  (type $e4 (sub $e3 (struct (field i32 (ref $e0) (mut i64)))))
-  (type $e5 (sub $e4 (struct (field i32 (ref $e1) (mut i64)))))
+  (type $e0 (sub open (struct)))
+  (type $e1 (sub open $e0 (struct)))
+  (type $e2 (sub open $e1 (struct (field i32))))
+  (type $e3 (sub open $e2 (struct (field i32 (ref null $e0)))))
+  (type $e4 (sub open $e3 (struct (field i32 (ref $e0) (mut i64)))))
+  (type $e5 (sub open $e4 (struct (field i32 (ref $e1) (mut i64)))))
 )
 
 (module
-  (type $s (sub (struct)))
-  (type $s' (sub $s (struct)))
+  (type $s (sub open (struct)))
+  (type $s' (sub open $s (struct)))
 
-  (type $f1 (sub (func (param (ref $s')) (result anyref))))
-  (type $f2 (sub $f1 (func (param (ref $s)) (result (ref any)))))
-  (type $f3 (sub $f2 (func (param (ref null $s)) (result (ref $s)))))
-  (type $f4 (sub $f3 (func (param (ref null struct)) (result (ref $s')))))
+  (type $f1 (sub open (func (param (ref $s')) (result anyref))))
+  (type $f2 (sub open $f1 (func (param (ref $s)) (result (ref any)))))
+  (type $f3 (sub open $f2 (func (param (ref null $s)) (result (ref $s)))))
+  (type $f4 (sub open $f3 (func (param (ref null struct)) (result (ref $s')))))
 )
 
 
 ;; Recursive definitions
 
 (module
-  (type $t (sub (struct (field anyref))))
-  (rec (type $r (sub $t (struct (field (ref $r))))))
-  (type $t' (sub $r (struct (field (ref $r) i32))))
+  (type $t (sub open (struct (field anyref))))
+  (rec (type $r (sub open $t (struct (field (ref $r))))))
+  (type $t' (sub open $r (struct (field (ref $r) i32))))
 )
 
 (module
   (rec
-    (type $r1 (sub (struct (field i32 (ref $r1)))))
+    (type $r1 (sub open (struct (field i32 (ref $r1)))))
   )
   (rec
-    (type $r2 (sub $r1 (struct (field i32 (ref $r3)))))
-    (type $r3 (sub $r1 (struct (field i32 (ref $r2)))))
+    (type $r2 (sub open $r1 (struct (field i32 (ref $r3)))))
+    (type $r3 (sub open $r1 (struct (field i32 (ref $r2)))))
   )
 )
 
 (module
   (rec
-    (type $a1 (sub (struct (field i32 (ref $a2)))))
-    (type $a2 (sub (struct (field i64 (ref $a1)))))
+    (type $a1 (sub open (struct (field i32 (ref $a2)))))
+    (type $a2 (sub open (struct (field i64 (ref $a1)))))
   )
   (rec
-    (type $b1 (sub $a2 (struct (field i64 (ref $a1) i32))))
-    (type $b2 (sub $a1 (struct (field i32 (ref $a2) i32))))
-    (type $b3 (sub $a2 (struct (field i64 (ref $b2) i32))))
+    (type $b1 (sub open $a2 (struct (field i64 (ref $a1) i32))))
+    (type $b2 (sub open $a1 (struct (field i32 (ref $a2) i32))))
+    (type $b3 (sub open $a2 (struct (field i64 (ref $b2) i32))))
   )
 )
 
@@ -67,9 +67,9 @@
 
 (module
   (rec
-    (type $t1 (sub (func (param i32 (ref $t3)))))
-    (type $t2 (sub $t1 (func (param i32 (ref $t2)))))
-    (type $t3 (sub $t2 (func (param i32 (ref $t1)))))
+    (type $t1 (sub open (func (param i32 (ref $t3)))))
+    (type $t2 (sub open $t1 (func (param i32 (ref $t2)))))
+    (type $t3 (sub open $t2 (func (param i32 (ref $t1)))))
   )
 
   (func $f1 (param $r (ref $t1))
@@ -88,15 +88,15 @@
 
 (module
   (rec
-    (type $t1 (sub (func (result i32 (ref $u1)))))
-    (type $u1 (sub (func (result f32 (ref $t1)))))
+    (type $t1 (sub open (func (result i32 (ref $u1)))))
+    (type $u1 (sub open (func (result f32 (ref $t1)))))
   )
 
   (rec
-    (type $t2 (sub $t1 (func (result i32 (ref $u3)))))
-    (type $u2 (sub $u1 (func (result f32 (ref $t3)))))
-    (type $t3 (sub $t1 (func (result i32 (ref $u2)))))
-    (type $u3 (sub $u1 (func (result f32 (ref $t2)))))
+    (type $t2 (sub open $t1 (func (result i32 (ref $u3)))))
+    (type $u2 (sub open $u1 (func (result f32 (ref $t3)))))
+    (type $t3 (sub open $t1 (func (result i32 (ref $u2)))))
+    (type $u3 (sub open $u1 (func (result f32 (ref $t2)))))
   )
 
   (func $f1 (param $r (ref $t1))
@@ -113,24 +113,24 @@
 )
 
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
-  (rec (type $g1 (sub $f1 (func))) (type (struct)))
-  (rec (type $g2 (sub $f2 (func))) (type (struct)))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g1 (sub open $f1 (func))) (type (struct)))
+  (rec (type $g2 (sub open $f2 (func))) (type (struct)))
   (func $g (type $g2))
   (global (ref $g1) (ref.func $g))
 )
 
 (module
-  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
-  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec (type $f1 (sub open (func))) (type $s1 (sub open (struct (field (ref $f1))))))
+  (rec (type $f2 (sub open (func))) (type $s2 (sub open (struct (field (ref $f2))))))
   (rec
-    (type $g1 (sub $f1 (func)))
-    (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
+    (type $g1 (sub open $f1 (func)))
+    (type (sub open $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
   )
   (rec
-    (type $g2 (sub $f2 (func)))
-    (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
+    (type $g2 (sub open $f2 (func)))
+    (type (sub open $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
   )
   (func $g (type $g2))
   (global (ref $g1) (ref.func $g))
@@ -138,10 +138,10 @@
 
 (assert_invalid
   (module
-    (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-    (rec (type $f2 (sub (func))) (type (struct (field (ref $f1)))))
-    (rec (type $g1 (sub $f1 (func))) (type (struct)))
-    (rec (type $g2 (sub $f2 (func))) (type (struct)))
+    (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+    (rec (type $f2 (sub open (func))) (type (struct (field (ref $f1)))))
+    (rec (type $g1 (sub open $f1 (func))) (type (struct)))
+    (rec (type $g2 (sub open $f2 (func))) (type (struct)))
     (func $g (type $g2))
     (global (ref $g1) (ref.func $g))
   )
@@ -149,25 +149,25 @@
 )
 
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
-  (rec (type $g (sub $f1 (func))) (type (struct)))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g (sub open $f1 (func))) (type (struct)))
   (func $g (type $g))
   (global (ref $f1) (ref.func $g))
 )
 
 (module
-  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
-  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec (type $f1 (sub open (func))) (type $s1 (sub open (struct (field (ref $f1))))))
+  (rec (type $f2 (sub open (func))) (type $s2 (sub open (struct (field (ref $f2))))))
   (rec
-    (type $g1 (sub $f1 (func)))
-    (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
+    (type $g1 (sub open $f1 (func)))
+    (type (sub open $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
   )
   (rec
-    (type $g2 (sub $f2 (func)))
-    (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
+    (type $g2 (sub open $f2 (func)))
+    (type (sub open $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
   )
-  (rec (type $h (sub $g2 (func))) (type (struct)))
+  (rec (type $h (sub open $g2 (func))) (type (struct)))
   (func $h (type $h))
   (global (ref $f1) (ref.func $h))
   (global (ref $g1) (ref.func $h))
@@ -175,8 +175,8 @@
 
 
 (module
-  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
-  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
+  (rec (type $f11 (sub open (func (result (ref func))))) (type $f12 (sub open $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub open (func (result (ref func))))) (type $f22 (sub open $f21 (func (result (ref $f21))))))
   (func $f11 (type $f11) (unreachable))
   (func $f12 (type $f12) (unreachable))
   (global (ref $f11) (ref.func $f11))
@@ -186,10 +186,10 @@
 )
 
 (module
-  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
-  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
-  (rec (type $g11 (sub $f11 (func (result (ref func))))) (type $g12 (sub $g11 (func (result (ref $g11))))))
-  (rec (type $g21 (sub $f21 (func (result (ref func))))) (type $g22 (sub $g21 (func (result (ref $g21))))))
+  (rec (type $f11 (sub open (func (result (ref func))))) (type $f12 (sub open $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub open (func (result (ref func))))) (type $f22 (sub open $f21 (func (result (ref $f21))))))
+  (rec (type $g11 (sub open $f11 (func (result (ref func))))) (type $g12 (sub open $g11 (func (result (ref $g11))))))
+  (rec (type $g21 (sub open $f21 (func (result (ref func))))) (type $g22 (sub open $g21 (func (result (ref $g21))))))
   (func $g11 (type $g11) (unreachable))
   (func $g12 (type $g12) (unreachable))
   (global (ref $f11) (ref.func $g11))
@@ -204,8 +204,8 @@
 
 (assert_invalid
   (module
-    (rec (type $f11 (sub (func))) (type $f12 (sub $f11 (func))))
-    (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+    (rec (type $f11 (sub open (func))) (type $f12 (sub open $f11 (func))))
+    (rec (type $f21 (sub open (func))) (type $f22 (sub open $f11 (func))))
     (func $f (type $f21))
     (global (ref $f11) (ref.func $f))
   )
@@ -214,9 +214,9 @@
 
 (assert_invalid
   (module
-    (rec (type $f01 (sub (func))) (type $f02 (sub $f01 (func))))
-    (rec (type $f11 (sub (func))) (type $f12 (sub $f01 (func))))
-    (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+    (rec (type $f01 (sub open (func))) (type $f02 (sub open $f01 (func))))
+    (rec (type $f11 (sub open (func))) (type $f12 (sub open $f01 (func))))
+    (rec (type $f21 (sub open (func))) (type $f22 (sub open $f11 (func))))
     (func $f (type $f21))
     (global (ref $f11) (ref.func $f))
   )
@@ -227,9 +227,9 @@
 ;; Runtime types
 
 (module
-  (type $t0 (sub (func (result (ref null func)))))
-  (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
-  (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+  (type $t0 (sub open (func (result (ref null func)))))
+  (rec (type $t1 (sub open $t0 (func (result (ref null $t1))))))
+  (rec (type $t2 (sub open $t1 (func (result (ref null $t2))))))
 
   (func $f0 (type $t0) (ref.null func))
   (func $f1 (type $t1) (ref.null $t1))
@@ -288,7 +288,7 @@
 (assert_trap (invoke "fail6") "cast")
 
 (module
-  (type $t1 (sub (func)))
+  (type $t1 (sub open (func)))
   (type $t2 (sub final (func)))
 
   (func $f1 (type $t1))
@@ -318,10 +318,10 @@
 
 
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
-  (rec (type $g1 (sub $f1 (func))) (type (struct)))
-  (rec (type $g2 (sub $f2 (func))) (type (struct)))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g1 (sub open $f1 (func))) (type (struct)))
+  (rec (type $g2 (sub open $f2 (func))) (type (struct)))
   (func $g (type $g2)) (elem declare func $g)
   (func (export "run") (result i32)
     (ref.test (ref $g1) (ref.func $g))
@@ -330,15 +330,15 @@
 (assert_return (invoke "run") (i32.const 1))
 
 (module
-  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
-  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec (type $f1 (sub open (func))) (type $s1 (sub open (struct (field (ref $f1))))))
+  (rec (type $f2 (sub open (func))) (type $s2 (sub open (struct (field (ref $f2))))))
   (rec
-    (type $g1 (sub $f1 (func)))
-    (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
+    (type $g1 (sub open $f1 (func)))
+    (type (sub open $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
   )
   (rec
-    (type $g2 (sub $f2 (func)))
-    (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
+    (type $g2 (sub open $f2 (func)))
+    (type (sub open $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
   )
   (func $g (type $g2)) (elem declare func $g)
   (func (export "run") (result i32)
@@ -348,10 +348,10 @@
 (assert_return (invoke "run") (i32.const 1))
 
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $g1 (sub $f1 (func))) (type (struct)))
-  (rec (type $g2 (sub $f2 (func))) (type (struct)))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $g1 (sub open $f1 (func))) (type (struct)))
+  (rec (type $g2 (sub open $f2 (func))) (type (struct)))
   (func $g (type $g2)) (elem declare func $g)
   (func (export "run") (result i32)
     (ref.test (ref $g1) (ref.func $g))
@@ -360,9 +360,9 @@
 (assert_return (invoke "run") (i32.const 0))
 
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
-  (rec (type $g (sub $f1 (func))) (type (struct)))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g (sub open $f1 (func))) (type (struct)))
   (func $g (type $g)) (elem declare func $g)
   (func (export "run") (result i32)
     (ref.test (ref $f1) (ref.func $g))
@@ -371,17 +371,17 @@
 (assert_return (invoke "run") (i32.const 1))
 
 (module
-  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
-  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec (type $f1 (sub open (func))) (type $s1 (sub open (struct (field (ref $f1))))))
+  (rec (type $f2 (sub open (func))) (type $s2 (sub open (struct (field (ref $f2))))))
   (rec
-    (type $g1 (sub $f1 (func)))
-    (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
+    (type $g1 (sub open $f1 (func)))
+    (type (sub open $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
   )
   (rec
-    (type $g2 (sub $f2 (func)))
-    (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
+    (type $g2 (sub open $f2 (func)))
+    (type (sub open $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
   )
-  (rec (type $h (sub $g2 (func))) (type (struct)))
+  (rec (type $h (sub open $g2 (func))) (type (struct)))
   (func $h (type $h)) (elem declare func $h)
   (func (export "run") (result i32 i32)
     (ref.test (ref $f1) (ref.func $h))
@@ -392,8 +392,8 @@
 
 
 (module
-  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
-  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
+  (rec (type $f11 (sub open (func (result (ref func))))) (type $f12 (sub open $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub open (func (result (ref func))))) (type $f22 (sub open $f21 (func (result (ref $f21))))))
   (func $f11 (type $f11) (unreachable)) (elem declare func $f11)
   (func $f12 (type $f12) (unreachable)) (elem declare func $f12)
   (func (export "run") (result i32 i32 i32 i32)
@@ -408,10 +408,10 @@
 )
 
 (module
-  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
-  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
-  (rec (type $g11 (sub $f11 (func (result (ref func))))) (type $g12 (sub $g11 (func (result (ref $g11))))))
-  (rec (type $g21 (sub $f21 (func (result (ref func))))) (type $g22 (sub $g21 (func (result (ref $g21))))))
+  (rec (type $f11 (sub open (func (result (ref func))))) (type $f12 (sub open $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub open (func (result (ref func))))) (type $f22 (sub open $f21 (func (result (ref $f21))))))
+  (rec (type $g11 (sub open $f11 (func (result (ref func))))) (type $g12 (sub open $g11 (func (result (ref $g11))))))
+  (rec (type $g21 (sub open $f21 (func (result (ref func))))) (type $g22 (sub open $g21 (func (result (ref $g21))))))
   (func $g11 (type $g11) (unreachable)) (elem declare func $g11)
   (func $g12 (type $g12) (unreachable)) (elem declare func $g12)
   (func (export "run") (result i32 i32 i32 i32 i32 i32 i32 i32)
@@ -431,8 +431,8 @@
 )
 
 (module
-  (rec (type $f11 (sub (func))) (type $f12 (sub $f11 (func))))
-  (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+  (rec (type $f11 (sub open (func))) (type $f12 (sub open $f11 (func))))
+  (rec (type $f21 (sub open (func))) (type $f22 (sub open $f11 (func))))
   (func $f (type $f21)) (elem declare func $f)
   (func (export "run") (result i32)
     (ref.test (ref $f11) (ref.func $f))
@@ -441,9 +441,9 @@
 (assert_return (invoke "run") (i32.const 0))
 
 (module
-  (rec (type $f01 (sub (func))) (type $f02 (sub $f01 (func))))
-  (rec (type $f11 (sub (func))) (type $f12 (sub $f01 (func))))
-  (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+  (rec (type $f01 (sub open (func))) (type $f02 (sub open $f01 (func))))
+  (rec (type $f11 (sub open (func))) (type $f12 (sub open $f01 (func))))
+  (rec (type $f21 (sub open (func))) (type $f22 (sub open $f11 (func))))
   (func $f (type $f21)) (elem declare func $f)
   (func (export "run") (result i32)
     (ref.test (ref $f11) (ref.func $f))
@@ -456,9 +456,9 @@
 ;; Linking
 
 (module
-  (type $t0 (sub (func (result (ref null func)))))
-  (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
-  (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+  (type $t0 (sub open (func (result (ref null func)))))
+  (rec (type $t1 (sub open $t0 (func (result (ref null $t1))))))
+  (rec (type $t2 (sub open $t1 (func (result (ref null $t2))))))
 
   (func (export "f0") (type $t0) (ref.null func))
   (func (export "f1") (type $t1) (ref.null $t1))
@@ -467,9 +467,9 @@
 (register "M")
 
 (module
-  (type $t0 (sub (func (result (ref null func)))))
-  (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
-  (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+  (type $t0 (sub open (func (result (ref null func)))))
+  (rec (type $t1 (sub open $t0 (func (result (ref null $t1))))))
+  (rec (type $t2 (sub open $t1 (func (result (ref null $t2))))))
 
   (func (import "M" "f0") (type $t0))
   (func (import "M" "f1") (type $t0))
@@ -481,9 +481,9 @@
 
 (assert_unlinkable
   (module
-    (type $t0 (sub (func (result (ref null func)))))
-    (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
-    (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+    (type $t0 (sub open (func (result (ref null func)))))
+    (rec (type $t1 (sub open $t0 (func (result (ref null $t1))))))
+    (rec (type $t2 (sub open $t1 (func (result (ref null $t2))))))
     (func (import "M" "f0") (type $t1))
   )
   "incompatible import type"
@@ -491,9 +491,9 @@
 
 (assert_unlinkable
   (module
-    (type $t0 (sub (func (result (ref null func)))))
-    (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
-    (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+    (type $t0 (sub open (func (result (ref null func)))))
+    (rec (type $t1 (sub open $t0 (func (result (ref null $t1))))))
+    (rec (type $t2 (sub open $t1 (func (result (ref null $t2))))))
     (func (import "M" "f0") (type $t2))
   )
   "incompatible import type"
@@ -501,16 +501,16 @@
 
 (assert_unlinkable
   (module
-    (type $t0 (sub (func (result (ref null func)))))
-    (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
-    (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+    (type $t0 (sub open (func (result (ref null func)))))
+    (rec (type $t1 (sub open $t0 (func (result (ref null $t1))))))
+    (rec (type $t2 (sub open $t1 (func (result (ref null $t2))))))
     (func (import "M" "f1") (type $t2))
   )
   "incompatible import type"
 )
 
 (module
-  (type $t1 (sub (func)))
+  (type $t1 (sub open (func)))
   (type $t2 (sub final (func)))
   (func (export "f1") (type $t1))
   (func (export "f2") (type $t2))
@@ -519,7 +519,7 @@
 
 (assert_unlinkable
   (module
-    (type $t1 (sub (func)))
+    (type $t1 (sub open (func)))
     (type $t2 (sub final (func)))
     (func (import "M2" "f1") (type $t2))
   )
@@ -527,7 +527,7 @@
 )
 (assert_unlinkable
   (module
-    (type $t1 (sub (func)))
+    (type $t1 (sub open (func)))
     (type $t2 (sub final (func)))
     (func (import "M2" "f2") (type $t1))
   )
@@ -536,101 +536,101 @@
 
 
 (module
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
-  (rec (type $g2 (sub $f2 (func))) (type (struct)))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g2 (sub open $f2 (func))) (type (struct)))
   (func (export "g") (type $g2))
 )
 (register "M")
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $g1 (sub $f1 (func))) (type (struct)))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $g1 (sub open $f1 (func))) (type (struct)))
   (func (import "M" "g") (type $g1))
 )
 
 (module
-  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
-  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec (type $f1 (sub open (func))) (type $s1 (sub open (struct (field (ref $f1))))))
+  (rec (type $f2 (sub open (func))) (type $s2 (sub open (struct (field (ref $f2))))))
   (rec
-    (type $g2 (sub $f2 (func)))
-    (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
+    (type $g2 (sub open $f2 (func)))
+    (type (sub open $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
   )
   (func (export "g") (type $g2))
 )
 (register "M")
 (module
-  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
-  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec (type $f1 (sub open (func))) (type $s1 (sub open (struct (field (ref $f1))))))
+  (rec (type $f2 (sub open (func))) (type $s2 (sub open (struct (field (ref $f2))))))
   (rec
-    (type $g1 (sub $f1 (func)))
-    (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
+    (type $g1 (sub open $f1 (func)))
+    (type (sub open $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
   )
   (func (import "M" "g") (type $g1))
 )
 
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $g2 (sub $f2 (func))) (type (struct)))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $g2 (sub open $f2 (func))) (type (struct)))
   (func (export "g") (type $g2))
 )
 (register "M")
 (assert_unlinkable
   (module
-    (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-    (rec (type $g1 (sub $f1 (func))) (type (struct)))
+    (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+    (rec (type $g1 (sub open $f1 (func))) (type (struct)))
     (func (import "M" "g") (type $g1))
   )
   "incompatible import"
 )
 
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
-  (rec (type $g (sub $f1 (func))) (type (struct)))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g (sub open $f1 (func))) (type (struct)))
   (func (export "g") (type $g))
 )
 (register "M")
 (module
-  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
-  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
-  (rec (type $g (sub $f1 (func))) (type (struct)))
+  (rec (type $f1 (sub open (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub open (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g (sub open $f1 (func))) (type (struct)))
   (func (import "M" "g") (type $f1))
 )
 
 (module
-  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
-  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec (type $f1 (sub open (func))) (type $s1 (sub open (struct (field (ref $f1))))))
+  (rec (type $f2 (sub open (func))) (type $s2 (sub open (struct (field (ref $f2))))))
   (rec
-    (type $g2 (sub $f2 (func)))
-    (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
+    (type $g2 (sub open $f2 (func)))
+    (type (sub open $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
   )
-  (rec (type $h (sub $g2 (func))) (type (struct)))
+  (rec (type $h (sub open $g2 (func))) (type (struct)))
   (func (export "h") (type $h))
 )
 (register "M")
 (module
-  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
-  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec (type $f1 (sub open (func))) (type $s1 (sub open (struct (field (ref $f1))))))
+  (rec (type $f2 (sub open (func))) (type $s2 (sub open (struct (field (ref $f2))))))
   (rec
-    (type $g1 (sub $f1 (func)))
-    (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
+    (type $g1 (sub open $f1 (func)))
+    (type (sub open $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
   )
-  (rec (type $h (sub $g1 (func))) (type (struct)))
+  (rec (type $h (sub open $g1 (func))) (type (struct)))
   (func (import "M" "h") (type $f1))
   (func (import "M" "h") (type $g1))
 )
 
 
 (module
-  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
-  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
+  (rec (type $f11 (sub open (func (result (ref func))))) (type $f12 (sub open $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub open (func (result (ref func))))) (type $f22 (sub open $f21 (func (result (ref $f21))))))
   (func (export "f11") (type $f11) (unreachable))
   (func (export "f12") (type $f12) (unreachable))
 )
 (register "M")
 (module
-  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
-  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
+  (rec (type $f11 (sub open (func (result (ref func))))) (type $f12 (sub open $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub open (func (result (ref func))))) (type $f22 (sub open $f21 (func (result (ref $f21))))))
   (func (import "M" "f11") (type $f11))
   (func (import "M" "f11") (type $f21))
   (func (import "M" "f12") (type $f12))
@@ -638,19 +638,19 @@
 )
 
 (module
-  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
-  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
-  (rec (type $g11 (sub $f11 (func (result (ref func))))) (type $g12 (sub $g11 (func (result (ref $g11))))))
-  (rec (type $g21 (sub $f21 (func (result (ref func))))) (type $g22 (sub $g21 (func (result (ref $g21))))))
+  (rec (type $f11 (sub open (func (result (ref func))))) (type $f12 (sub open $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub open (func (result (ref func))))) (type $f22 (sub open $f21 (func (result (ref $f21))))))
+  (rec (type $g11 (sub open $f11 (func (result (ref func))))) (type $g12 (sub open $g11 (func (result (ref $g11))))))
+  (rec (type $g21 (sub open $f21 (func (result (ref func))))) (type $g22 (sub open $g21 (func (result (ref $g21))))))
   (func (export "g11") (type $g11) (unreachable))
   (func (export "g12") (type $g12) (unreachable))
 )
 (register "M")
 (module
-  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
-  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
-  (rec (type $g11 (sub $f11 (func (result (ref func))))) (type $g12 (sub $g11 (func (result (ref $g11))))))
-  (rec (type $g21 (sub $f21 (func (result (ref func))))) (type $g22 (sub $g21 (func (result (ref $g21))))))
+  (rec (type $f11 (sub open (func (result (ref func))))) (type $f12 (sub open $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub open (func (result (ref func))))) (type $f22 (sub open $f21 (func (result (ref $f21))))))
+  (rec (type $g11 (sub open $f11 (func (result (ref func))))) (type $g12 (sub open $g11 (func (result (ref $g11))))))
+  (rec (type $g21 (sub open $f21 (func (result (ref func))))) (type $g22 (sub open $g21 (func (result (ref $g21))))))
   (func (import "M" "g11") (type $f11))
   (func (import "M" "g11") (type $f21))
   (func (import "M" "g12") (type $f11))
@@ -662,30 +662,30 @@
 )
 
 (module
-  (rec (type $f11 (sub (func))) (type $f12 (sub $f11 (func))))
-  (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+  (rec (type $f11 (sub open (func))) (type $f12 (sub open $f11 (func))))
+  (rec (type $f21 (sub open (func))) (type $f22 (sub open $f11 (func))))
   (func (export "f") (type $f21))
 )
 (register "M")
 (assert_unlinkable
   (module
-    (rec (type $f11 (sub (func))) (type $f12 (sub $f11 (func))))
+    (rec (type $f11 (sub open (func))) (type $f12 (sub open $f11 (func))))
     (func (import "M" "f") (type $f11))
   )
   "incompatible import"
 )
 
 (module
-  (rec (type $f01 (sub (func))) (type $f02 (sub $f01 (func))))
-  (rec (type $f11 (sub (func))) (type $f12 (sub $f01 (func))))
-  (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+  (rec (type $f01 (sub open (func))) (type $f02 (sub open $f01 (func))))
+  (rec (type $f11 (sub open (func))) (type $f12 (sub open $f01 (func))))
+  (rec (type $f21 (sub open (func))) (type $f22 (sub open $f11 (func))))
   (func (export "f") (type $f21))
 )
 (register "M")
 (assert_unlinkable
   (module
-    (rec (type $f01 (sub (func))) (type $f02 (sub $f01 (func))))
-    (rec (type $f11 (sub (func))) (type $f12 (sub $f01 (func))))
+    (rec (type $f01 (sub open (func))) (type $f02 (sub open $f01 (func))))
+    (rec (type $f11 (sub open (func))) (type $f12 (sub open $f01 (func))))
     (func (import "M" "f") (type $f11))
   )
   "incompatible import"
@@ -698,7 +698,7 @@
 (assert_invalid
   (module
     (type $t (func))
-    (type $s (sub $t (func)))
+    (type $s (sub open $t (func)))
   )
   "sub type"
 )
@@ -706,7 +706,7 @@
 (assert_invalid
   (module
     (type $t (struct))
-    (type $s (sub $t (struct)))
+    (type $s (sub open $t (struct)))
   )
   "sub type"
 )
@@ -714,16 +714,16 @@
 (assert_invalid
   (module
     (type $t (sub final (func)))
-    (type $s (sub $t (func)))
+    (type $s (sub open $t (func)))
   )
   "sub type"
 )
 
 (assert_invalid
   (module
-    (type $t (sub (func)))
+    (type $t (sub open (func)))
     (type $s (sub final $t (func)))
-    (type $u (sub $s (func)))
+    (type $u (sub open $s (func)))
   )
   "sub type"
 )
@@ -734,73 +734,72 @@
 
 (assert_invalid
   (module
-    (type $a0 (sub (array i32)))
-    (type $s0 (sub $a0 (struct)))
-  )
-  "sub type"
-)
-
-(assert_invalid 
-  (module
-    (type $f0 (sub (func (param i32) (result i32))))
-    (type $s0 (sub $f0 (struct)))
+    (type $a0 (sub open (array i32)))
+    (type $s0 (sub open $a0 (struct)))
   )
   "sub type"
 )
 
 (assert_invalid
   (module
-    (type $s0 (sub (struct)))
-    (type $a0 (sub $s0 (array i32)))
+    (type $f0 (sub open (func (param i32) (result i32))))
+    (type $s0 (sub open $f0 (struct)))
   )
   "sub type"
 )
 
 (assert_invalid
   (module
-    (type $f0 (sub (func (param i32) (result i32))))
-    (type $a0 (sub $f0 (array i32)))
-  )
-  "sub type"
-)
-
-(assert_invalid 
-  (module
-    (type $s0 (sub (struct)))
-    (type $f0 (sub $s0 (func (param i32) (result i32))))
-  )
-  "sub type"
-)
-
-(assert_invalid 
-  (module
-    (type $a0 (sub (array i32)))
-    (type $f0 (sub $a0 (func (param i32) (result i32))))
+    (type $s0 (sub open (struct)))
+    (type $a0 (sub open $s0 (array i32)))
   )
   "sub type"
 )
 
 (assert_invalid
   (module
-    (type $a0 (sub (array i32)))
-    (type $a1 (sub $a0 (array i64)))
+    (type $f0 (sub open (func (param i32) (result i32))))
+    (type $a0 (sub open $f0 (array i32)))
   )
   "sub type"
 )
 
 (assert_invalid
   (module
-    (type $s0 (sub (struct (field i32))))
-    (type $s1 (sub $s0 (struct (field i64))))
+    (type $s0 (sub open (struct)))
+    (type $f0 (sub open $s0 (func (param i32) (result i32))))
   )
   "sub type"
 )
 
 (assert_invalid
   (module
-    (type $f0 (sub (func)))
-    (type $f1 (sub $f0 (func (param i32))))
+    (type $a0 (sub open (array i32)))
+    (type $f0 (sub open $a0 (func (param i32) (result i32))))
   )
   "sub type"
 )
 
+(assert_invalid
+  (module
+    (type $a0 (sub open (array i32)))
+    (type $a1 (sub open $a0 (array i64)))
+  )
+  "sub type"
+)
+
+(assert_invalid
+  (module
+    (type $s0 (sub open (struct (field i32))))
+    (type $s1 (sub open $s0 (struct (field i64))))
+  )
+  "sub type"
+)
+
+(assert_invalid
+  (module
+    (type $f0 (sub open (func)))
+    (type $f1 (sub open $f0 (func (param i32))))
+  )
+  "sub type"
+)


### PR DESCRIPTION
Instead of using final? in the syntax, use ext ::= open | final. Implements the
design discussed in #413. Update the interpreter, the abstract syntax, the
binary and text formats, and MVP.md.