### PR TITLE
Test that br_on_cast{_fail} must do a down cast

### DIFF
--- a/test/core/gc/br_on_cast.wast
+++ b/test/core/gc/br_on_cast.wast
@@ -249,3 +249,11 @@
   )
   "type mismatch"
 )
+(assert_invalid
+  (module
+    (func (result anyref)
+      (br_on_cast 0 eqref anyref (unreachable))
+    )
+  )
+  "type mismatch"
+)

--- a/test/core/gc/br_on_cast_fail.wast
+++ b/test/core/gc/br_on_cast_fail.wast
@@ -264,3 +264,11 @@
   )
   "type mismatch"
 )
+(assert_invalid
+  (module
+    (func (result anyref)
+      (br_on_cast_fail 0 eqref anyref (unreachable))
+    )
+  )
+  "type mismatch"
+)


### PR DESCRIPTION
Add tests checking for validation failures if the output type of br_on_cast or
br_on_cast_fail is not a subtype of the input type.