### PR TITLE
Test that "sideways" br_on_casts are not allowed

### DIFF
--- a/test/core/gc/br_on_cast.wast
+++ b/test/core/gc/br_on_cast.wast
@@ -257,3 +257,11 @@
   )
   "type mismatch"
 )
+(assert_invalid
+  (module
+    (func (result anyref)
+      (br_on_cast 0 structref arrayref (unreachable))
+    )
+  )
+  "type mismatch"
+)

--- a/test/core/gc/br_on_cast_fail.wast
+++ b/test/core/gc/br_on_cast_fail.wast
@@ -272,3 +272,11 @@
   )
   "type mismatch"
 )
+(assert_invalid
+  (module
+    (func (result anyref)
+      (br_on_cast_fail 0 structref arrayref (unreachable))
+    )
+  )
+  "type mismatch"
+)


### PR DESCRIPTION
I had intended this to be included in #424, but better late than never.