### PR TITLE
Remove incorrect link to abstract syntax

### DIFF
--- a/document/core/text/types.rst
+++ b/document/core/text/types.rst
@@ -263,7 +263,7 @@ Recursive Types
 Abbreviations
 .............
 
-Singular recursive types can omit the |Trec| keyword:
+Singular recursive types can omit the :math:`\text{rec}` keyword:
 
 .. math::
    \begin{array}{llclll}


### PR DESCRIPTION
When referring to the `rec` keyword, do not link to the abstract syntax that
happens to have the same name. Fix suggested by @bvisness and split out from
https://github.com/WebAssembly/gc/pull/413.

Do not link to the abstract syntax