### PR TITLE
Rename text "deftype" to "typedef"

### DIFF
--- a/document/core/text/modules.rst
+++ b/document/core/text/modules.rst
@@ -670,8 +670,8 @@ The definition of the initial :ref:`identifier context <text-context>` :math:`I`
 
 .. math::
    \begin{array}{@{}lcl@{\qquad\qquad}l}
-   \F{idc}(\text{(}~\text{rec}~~\Tdeftype^\ast~\text{)}) &=&
-     \bigcompose \F{idc}(\Tdeftype)^\ast \\
+   \F{idc}(\text{(}~\text{rec}~~\Ttypedef^\ast~\text{)}) &=&
+     \bigcompose \F{idc}(\Ttypedef)^\ast \\
    \F{idc}(\text{(}~\text{type}~\Tid^?~\Tsubtype~\text{)}) &=&
      \{\ITYPES~(\Tid^?), \IFIELDS~\F{idf}(\Tsubtype), \ITYPEDEFS~\X{st}\} \\
    \F{idc}(\text{(}~\text{func}~\Tid^?~\dots~\text{)}) &=&

--- a/document/core/text/types.rst
+++ b/document/core/text/types.rst
@@ -241,7 +241,7 @@ Composite Types
    pair: text format; sub type
 .. _text-rectype:
 .. _text-subtype:
-.. _text-deftype:
+.. _text-typedef:
 
 Recursive Types
 ~~~~~~~~~~~~~~~
@@ -249,9 +249,9 @@ Recursive Types
 .. math::
    \begin{array}{llclll@{\qquad\qquad}l}
    \production{recursive type} & \Trectype_I &::=&
-     \text{(}~\text{rec}~~\X{st}^\ast{:\,}\Tvec(\Tdeftype_I)~\text{)}
+     \text{(}~\text{rec}~~\X{st}^\ast{:\,}\Tvec(\Ttypedef_I)~\text{)}
        &\Rightarrow& \TREC~\X{st}^\ast \\
-   \production{defined type} & \Tdeftype_I &::=&
+   \production{defined type} & \Ttypedef_I &::=&
      \text{(}~\text{type}~~\Tid^?~~\X{st}{:}\Tsubtype_I~\text{)}
        &\Rightarrow& \X{st} \\
    \production{sub type} & \Tsubtype_I &::=&
@@ -268,8 +268,8 @@ Singular recursive types can omit the :math:`\text{rec}` keyword:
 .. math::
    \begin{array}{llclll}
    \production{recursive type} &
-     \Tsubtype &\equiv&
-     \text{(}~~\text{rec}~~\Tsubtype~~\text{)} \\
+     \Ttypedef &\equiv&
+     \text{(}~~\text{rec}~~\Ttypedef~~\text{)} \\
    \end{array}
 
 Similarly, final sub types with no super-types can omit the |Tsub| keyword and arguments:

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -908,7 +908,7 @@
 .. |Tpackedtype| mathdef:: \xref{text/types}{text-packedtype}{\T{packedtype}}
 .. |Tcomptype| mathdef:: \xref{text/types}{text-comptype}{\T{comptype}}
 .. |Tsubtype| mathdef:: \xref{text/types}{text-subtype}{\T{subtype}}
-.. |Tdeftype| mathdef:: \xref{text/types}{text-deftype}{\T{deftype}}
+.. |Ttypedef| mathdef:: \xref{text/types}{text-typedef}{\T{typedef}}
 .. |Trectype| mathdef:: \xref{text/types}{text-rectype}{\T{rectype}}
 
 .. |Tglobaltype| mathdef:: \xref{text/types}{text-globaltype}{\T{globaltype}}


### PR DESCRIPTION
Since a deftype is already something else outside the text format. Also fix an
abbreviation to correctly use "typedef" instead of "subtype". Adapted from a fix
by @bvisness in #413.