### PR TITLE
[test] Prevent from module name conflict when registering in wast.

### DIFF
--- a/test/core/gc/type-subtyping.wast
+++ b/test/core/gc/type-subtyping.wast
@@ -540,11 +540,11 @@
   (rec (type $g2 (sub $f2 (func))) (type (struct)))
   (func (export "g") (type $g2))
 )
-(register "M")
+(register "M3")
 (module
   (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
   (rec (type $g1 (sub $f1 (func))) (type (struct)))
-  (func (import "M" "g") (type $g1))
+  (func (import "M3" "g") (type $g1))
 )
 
 (module
@@ -556,7 +556,7 @@
   )
   (func (export "g") (type $g2))
 )
-(register "M")
+(register "M4")
 (module
   (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
   (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
@@ -564,7 +564,7 @@
     (type $g1 (sub $f1 (func)))
     (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
   )
-  (func (import "M" "g") (type $g1))
+  (func (import "M4" "g") (type $g1))
 )
 
 (module
@@ -573,12 +573,12 @@
   (rec (type $g2 (sub $f2 (func))) (type (struct)))
   (func (export "g") (type $g2))
 )
-(register "M")
+(register "M5")
 (assert_unlinkable
   (module
     (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
     (rec (type $g1 (sub $f1 (func))) (type (struct)))
-    (func (import "M" "g") (type $g1))
+    (func (import "M5" "g") (type $g1))
   )
   "incompatible import"
 )
@@ -589,12 +589,12 @@
   (rec (type $g (sub $f1 (func))) (type (struct)))
   (func (export "g") (type $g))
 )
-(register "M")
+(register "M6")
 (module
   (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
   (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
   (rec (type $g (sub $f1 (func))) (type (struct)))
-  (func (import "M" "g") (type $f1))
+  (func (import "M6" "g") (type $f1))
 )
 
 (module
@@ -607,7 +607,7 @@
   (rec (type $h (sub $g2 (func))) (type (struct)))
   (func (export "h") (type $h))
 )
-(register "M")
+(register "M7")
 (module
   (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
   (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
@@ -616,8 +616,8 @@
     (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
   )
   (rec (type $h (sub $g1 (func))) (type (struct)))
-  (func (import "M" "h") (type $f1))
-  (func (import "M" "h") (type $g1))
+  (func (import "M7" "h") (type $f1))
+  (func (import "M7" "h") (type $g1))
 )
 
 
@@ -627,14 +627,14 @@
   (func (export "f11") (type $f11) (unreachable))
   (func (export "f12") (type $f12) (unreachable))
 )
-(register "M")
+(register "M8")
 (module
   (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
   (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
-  (func (import "M" "f11") (type $f11))
-  (func (import "M" "f11") (type $f21))
-  (func (import "M" "f12") (type $f12))
-  (func (import "M" "f12") (type $f22))
+  (func (import "M8" "f11") (type $f11))
+  (func (import "M8" "f11") (type $f21))
+  (func (import "M8" "f12") (type $f12))
+  (func (import "M8" "f12") (type $f22))
 )
 
 (module
@@ -645,20 +645,20 @@
   (func (export "g11") (type $g11) (unreachable))
   (func (export "g12") (type $g12) (unreachable))
 )
-(register "M")
+(register "M9")
 (module
   (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
   (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
   (rec (type $g11 (sub $f11 (func (result (ref func))))) (type $g12 (sub $g11 (func (result (ref $g11))))))
   (rec (type $g21 (sub $f21 (func (result (ref func))))) (type $g22 (sub $g21 (func (result (ref $g21))))))
-  (func (import "M" "g11") (type $f11))
-  (func (import "M" "g11") (type $f21))
-  (func (import "M" "g12") (type $f11))
-  (func (import "M" "g12") (type $f21))
-  (func (import "M" "g11") (type $g11))
-  (func (import "M" "g11") (type $g21))
-  (func (import "M" "g12") (type $g12))
-  (func (import "M" "g12") (type $g22))
+  (func (import "M9" "g11") (type $f11))
+  (func (import "M9" "g11") (type $f21))
+  (func (import "M9" "g12") (type $f11))
+  (func (import "M9" "g12") (type $f21))
+  (func (import "M9" "g11") (type $g11))
+  (func (import "M9" "g11") (type $g21))
+  (func (import "M9" "g12") (type $g12))
+  (func (import "M9" "g12") (type $g22))
 )
 
 (module
@@ -666,11 +666,11 @@
   (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
   (func (export "f") (type $f21))
 )
-(register "M")
+(register "M10")
 (assert_unlinkable
   (module
     (rec (type $f11 (sub (func))) (type $f12 (sub $f11 (func))))
-    (func (import "M" "f") (type $f11))
+    (func (import "M10" "f") (type $f11))
   )
   "incompatible import"
 )
@@ -681,12 +681,12 @@
   (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
   (func (export "f") (type $f21))
 )
-(register "M")
+(register "M11")
 (assert_unlinkable
   (module
     (rec (type $f01 (sub (func))) (type $f02 (sub $f01 (func))))
     (rec (type $f11 (sub (func))) (type $f12 (sub $f01 (func))))
-    (func (import "M" "f") (type $f11))
+    (func (import "M11" "f") (type $f11))
   )
   "incompatible import"
 )

--- a/test/core/type-equivalence.wast
+++ b/test/core/type-equivalence.wast
@@ -234,10 +234,10 @@
   (rec (type $t1 (func (param i32 (ref $t1)))))
   (func (export "f") (param (ref $t1)))
 )
-(register "M")
+(register "Mr1")
 (module
   (rec (type $t2 (func (param i32 (ref $t2)))))
-  (func (import "M" "f") (param (ref $t2)))
+  (func (import "Mr1" "f") (param (ref $t2)))
 )
 
 
@@ -253,16 +253,16 @@
   (func (export "f2") (param (ref $t2)))
   (func (export "f3") (param (ref $t3)))
 )
-(register "M")
+(register "Mr2")
 (module
   (rec
     (type $t1 (func (param i32 (ref $t1))))
     (type $t2 (func (param i32 (ref $t3))))
     (type $t3 (func (param i32 (ref $t2))))
   )
-  (func (import "M" "f1") (param (ref $t1)))
-  (func (import "M" "f2") (param (ref $t2)))
-  (func (import "M" "f3") (param (ref $t3)))
+  (func (import "Mr2" "f1") (param (ref $t1)))
+  (func (import "Mr2" "f2") (param (ref $t2)))
+  (func (import "Mr2" "f3") (param (ref $t3)))
 )
 
 (module
@@ -275,16 +275,16 @@
   (func (export "f2") (param (ref $t2)))
   (func (export "f3") (param (ref $t3)))
 )
-(register "M")
+(register "Mr3")
 (module
   (rec
     (type $t1 (func (param i32 (ref $t3))))
     (type $t2 (func (param i32 (ref $t1))))
     (type $t3 (func (param i32 (ref $t2))))
   )
-  (func (import "M" "f1") (param (ref $t1)))
-  (func (import "M" "f2") (param (ref $t2)))
-  (func (import "M" "f3") (param (ref $t3)))
+  (func (import "Mr3" "f1") (param (ref $t1)))
+  (func (import "Mr3" "f2") (param (ref $t2)))
+  (func (import "Mr3" "f3") (param (ref $t3)))
 )
 
 (module
@@ -304,7 +304,7 @@
   (func (export "f2") (param (ref $t2)))
   (func (export "f3") (param (ref $t3)))
 )
-(register "M")
+(register "Mr4")
 (module
   (rec
     (type $t1 (func (param i32 (ref $u1))))
@@ -318,7 +318,7 @@
     (type $u3 (func (param f32 (ref $t2))))
   )
 
-  (func (import "M" "f1") (param (ref $t1)))
-  (func (import "M" "f2") (param (ref $t2)))
-  (func (import "M" "f3") (param (ref $t3)))
+  (func (import "Mr4" "f1") (param (ref $t1)))
+  (func (import "Mr4" "f2") (param (ref $t2)))
+  (func (import "Mr4" "f3") (param (ref $t3)))
 )


### PR DESCRIPTION
Such as the `register` commands in [linking.wast](https://github.com/WebAssembly/gc/blob/main/test/core/linking.wast), I think it's better to prevent from the module name conflict for each `register` commands in a `wast` file.