### PR TITLE
[spec] Fix typing of functions

### DIFF
--- a/document/core/exec/values.rst
+++ b/document/core/exec/values.rst
@@ -186,6 +186,26 @@ The following auxiliary typing rules specify this typing relation relative to a 
      S \vdashval \REFEXTERN~\reff : \REF~\NULL^?~\EXTERN
    }
 
+Subsumption
+...........
+
+* The value must be valid with some value type :math:`t`.
+
+* The value type :math:`t` :ref:`matches <match-valtype>` another :ref:`valid <valid-valtype>` type :math:`t'`.
+
+* Then the value is valid with type :math:`t'`.
+
+.. math::
+   \frac{
+     S \vdashval \val : t
+     \qquad
+     \vdashvaltype t' \ok
+     \qquad
+     \vdashvaltypematch t \matchesvaltype t'
+   }{
+     S \vdashval \val : t'
+   }
+
 
 .. index:: external value, external type, validation, import, store
 .. _valid-externval:
@@ -263,4 +283,24 @@ The following auxiliary typing rules specify this typing relation relative to a 
    \frac{
    }{
      S \vdashexternval \EVGLOBAL~a : \ETGLOBAL~S.\SGLOBALS[a].\GITYPE
+   }
+
+Subsumption
+...........
+
+* The external value must be valid with some external type :math:`\X{et}`.
+
+* The external type :math:`\X{et}` :ref:`matches <match-externtype>` another :ref:`valid <valid-externtype>` type :math:`\X{et'}`.
+
+* Then the external value is valid with type :math:`\X{et'}`.
+
+.. math::
+   \frac{
+     S \vdashexternval \externval : \X{et}
+     \qquad
+     \vdashexterntype \X{et'} \ok
+     \qquad
+     \vdashexterntypematch \X{et} \matchesexterntype \X{et'}
+   }{
+     S \vdashexternval \externval : \X{et'}
    }

--- a/document/core/syntax/types.rst
+++ b/document/core/syntax/types.rst
@@ -451,7 +451,7 @@ Conventions
 The following auxiliary notation is defined for sequences of external types.
 It filters out entries of a specific kind in an order-preserving fashion:
 
-* :math:`\etfuncs(\externtype^\ast) = [\functype ~|~ (\ETFUNC~\functype) \in \externtype^\ast]`
+* :math:`\etfuncs(\externtype^\ast) = [\deftype ~|~ (\ETFUNC~\deftype) \in \externtype^\ast]`
 
 * :math:`\ettables(\externtype^\ast) = [\tabletype ~|~ (\ETTABLE~\tabletype) \in \externtype^\ast]`
 

--- a/document/core/valid/conventions.rst
+++ b/document/core/valid/conventions.rst
@@ -249,7 +249,7 @@ Validity of an individual definition is specified relative to a *context*,
 which collects relevant information about the surrounding :ref:`module <syntax-module>` and the definitions in scope:
 
 * *Types*: the list of :ref:`types <syntax-type>` defined in the current module.
-* *Functions*: the list of :ref:`functions <syntax-func>` declared in the current module, represented by their :ref:`function type <syntax-functype>`.
+* *Functions*: the list of :ref:`functions <syntax-func>` declared in the current module, represented by a :ref:`defined type <syntax-deftype>` that :ref:`expands <aux-expand-deftype>` to their :ref:`function type <syntax-functype>`.
 * *Tables*: the list of :ref:`tables <syntax-table>` declared in the current module, represented by their :ref:`table type <syntax-tabletype>`.
 * *Memories*: the list of :ref:`memories <syntax-mem>` declared in the current module, represented by their :ref:`memory type <syntax-memtype>`.
 * *Globals*: the list of :ref:`globals <syntax-global>` declared in the current module, represented by their :ref:`global type <syntax-globaltype>`.
@@ -272,7 +272,7 @@ More concretely, contexts are defined as :ref:`records <notation-record>` :math:
    \production{context} & C &::=&
      \begin{array}[t]{l@{~}ll}
      \{ & \CTYPES & \deftype^\ast, \\
-        & \CFUNCS & \functype^\ast, \\
+        & \CFUNCS & \deftype^\ast, \\
         & \CTABLES & \tabletype^\ast, \\
         & \CMEMS & \memtype^\ast, \\
         & \CGLOBALS & \globaltype^\ast, \\

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -189,19 +189,19 @@ Reference Instructions
 
 * The function :math:`C.\CFUNCS[x]` must be defined in the context.
 
-* Let :math:`y` be the :ref:`type index <syntax-typeidx>` :math:`C.\CFUNCS[x]`.
+* Let :math:`\X{dt}` be the :ref:`defined type <syntax-deftype>` :math:`C.\CFUNCS[x]`.
 
 * The :ref:`function index <syntax-funcidx>` :math:`x` must be contained in :math:`C.\CREFS`.
 
-* The instruction is valid with type :math:`[] \to [(\REF~y)]`.
+* The instruction is valid with type :math:`[] \to [(\REF~\X{dt})]`.
 
 .. math::
    \frac{
-     C.\CFUNCS[x] = y
+     C.\CFUNCS[x] = \X{dt}
      \qquad
      x \in C.\CREFS
    }{
-     C \vdashinstr \REFFUNC~x : [] \to [(\REF~y)]
+     C \vdashinstr \REFFUNC~x : [] \to [(\REF~\X{dt})]
    }
 
 .. _valid-ref.is_null:
@@ -2166,17 +2166,13 @@ Control Instructions
 
 * The function :math:`C.\CFUNCS[x]` must be defined in the context.
 
-* Let :math:`y` be the :ref:`type index <syntax-typeidx>` :math:`C.\CFUNCS[x]`.
-
-* Assert: The type :math:`C.\CTYPES[y]` is defined in the context.
-
-* Let :math:`[t_1^\ast] \toF [t_2^\ast]` be the :ref:`function type <syntax-functype>` :math:`C.\CTYPES[y]`.
+* The :ref:`expansion <aux-expand-deftype>` of :math:`C.\CFUNCS[x]` must be a :ref:`function type <syntax-functype>` :math:`\TFUNC~[t_1^\ast] \toF [t_2^\ast]`.
 
 * Then the instruction is valid with type :math:`[t_1^\ast] \to [t_2^\ast]`.
 
 .. math::
    \frac{
-     C.\CTYPES[C.\CFUNCS[x]] = [t_1^\ast] \toF [t_2^\ast]
+     \expanddt(C.\CFUNCS[x]) = \TFUNC~[t_1^\ast] \toF [t_2^\ast]
    }{
      C \vdashinstr \CALL~x : [t_1^\ast] \to [t_2^\ast]
    }
@@ -2189,13 +2185,13 @@ Control Instructions
 
 * The type :math:`C.\CTYPES[x]` must be defined in the context.
 
-* Let :math:`[t_1^\ast] \toF [t_2^\ast]` be the :ref:`function type <syntax-functype>` :math:`C.\CTYPES[x]`.
+* The :ref:`expansion <aux-expand-deftype>` of :math:`C.\CFUNCS[x]` must be a :ref:`function type <syntax-functype>` :math:`\TFUNC~[t_1^\ast] \toF [t_2^\ast]`.
 
 * Then the instruction is valid with type :math:`[t_1^\ast~(\REF~\NULL~x)] \to [t_2^\ast]`.
 
 .. math::
    \frac{
-     C.\CTYPES[x] = [t_1^\ast] \toF [t_2^\ast]
+     \expanddt(C.\CTYPES[x]) = \TFUNC~[t_1^\ast] \toF [t_2^\ast]
    }{
      C \vdashinstr \CALLREF~x : [t_1^\ast~(\REF~\NULL~x)] \to [t_2^\ast]
    }
@@ -2239,7 +2235,7 @@ Control Instructions
 
 * The function :math:`C.\CFUNCS[x]` must be defined in the context.
 
-* Let :math:`[t_1^\ast] \toF [t_2^\ast]` be the :ref:`function type <syntax-functype>` :math:`C.\CFUNCS[x]`.
+* The :ref:`expansion <aux-expand-deftype>` of :math:`C.\CFUNCS[x]` must be a :ref:`function type <syntax-functype>` :math:`\TFUNC~[t_1^\ast] \toF [t_2^\ast]`.
 
 * The :ref:`result type <syntax-resulttype>` :math:`[t_2^\ast]` must :ref:`match <match-resulttype>` :math:`C.\CRETURN`.
 
@@ -2247,7 +2243,7 @@ Control Instructions
 
 .. math::
    \frac{
-     C.\CFUNCS[x] = [t_1^\ast] \toF [t_2^\ast]
+     \expanddt(C.\CFUNCS[x]) = \TFUNC~[t_1^\ast] \toF [t_2^\ast]
      \qquad
      C \vdashresulttypematch [t_2^\ast] \matchesresulttype C.\CRETURN
    }{

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -70,7 +70,7 @@ The sequence of :ref:`types <syntax-type>` defined in a module is validated incr
 Functions
 ~~~~~~~~~
 
-Functions :math:`\func` are classified by :ref:`type indices <syntax-typeidx>` referring to :ref:`function types <syntax-functype>` of the form :math:`[t_1^\ast] \toF [t_2^\ast]`.
+Functions :math:`\func` are classified by :ref:`defined types <syntax-deftype>` that :ref:`expand <aux-expand-deftype>` to :ref:`function types <syntax-functype>` of the form :math:`\TFUNC~[t_1^\ast] \toF [t_2^\ast]`.
 
 
 :math:`\{ \FTYPE~x, \FLOCALS~t^\ast, \FBODY~\expr \}`
@@ -98,7 +98,7 @@ Functions :math:`\func` are classified by :ref:`type indices <syntax-typeidx>` r
 * Under the context :math:`C'`,
   the expression :math:`\expr` must be valid with type :math:`[t_2^\ast]`.
 
-* Then the function definition is valid with type :math:`[t_1^\ast] \toF [t_2^\ast]`.
+* Then the function definition is valid with type :math:`C.\CTYPES[x]`.
 
 .. math::
    \frac{
@@ -108,7 +108,7 @@ Functions :math:`\func` are classified by :ref:`type indices <syntax-typeidx>` r
      \qquad
      C,\CLOCALS\,(\SET~t_1)^\ast~(\init~t)^\ast,\CLABELS~[t_2^\ast],\CRETURN~[t_2^\ast] \vdashexpr \expr : [t_2^\ast]
    }{
-     C \vdashfunc \{ \FTYPE~x, \FLOCALS~t^\ast, \FBODY~\expr \} : x
+     C \vdashfunc \{ \FTYPE~x, \FLOCALS~t^\ast, \FBODY~\expr \} : C.\CTYPES[x]
    }
 
 
@@ -466,18 +466,14 @@ Start function declarations :math:`\start` are not classified by any type.
 
 * The function :math:`C.\CFUNCS[x]` must be defined in the context.
 
-* Let :math:`y` be the :ref:`type index <syntax-typeidx>` :math:`C.\CFUNCS[x]`.
-
-* Assert: The type :math:`C.\CTYPES[y]` is defined in the context.
-
-* The type :math:`C.\CTYPES[y]` must be the :ref:`function type <syntax-functype>` :math:`\TFUNC~[] \toF []`.
+* The :ref:`expansion <aux-expand-deftype>` of :math:`C.\CFUNCS[x]` must be a :ref:`function type <syntax-functype>` :math:`\TFUNC~[] \toF []`.
 
 * Then the start function is valid.
 
 
 .. math::
    \frac{
-     C.\CTYPES[C.\CFUNCS[x]] = \TFUNC~[] \toF []
+     \expanddt(C.\CFUNCS[x]) = \TFUNC~[] \toF []
    }{
      C \vdashstart \{ \SFUNC~x \} \ok
    }
@@ -515,13 +511,15 @@ Exports :math:`\export` and export descriptions :math:`\exportdesc` are classifi
 
 * The function :math:`C.\CFUNCS[x]` must be defined in the context.
 
-* Then the export description is valid with :ref:`external type <syntax-externtype>` :math:`\ETFUNC~C.\CFUNCS[x]`.
+* Let :math:`\X{dt}` be the :ref:`defined type <syntax-deftype>` :math:`C.\CFUNCS[x]`.
+
+* Then the export description is valid with :ref:`external type <syntax-externtype>` :math:`\ETFUNC~\X{dt}`.
 
 .. math::
    \frac{
-     C.\CFUNCS[x] = \functype
+     C.\CFUNCS[x] = \X{dt}
    }{
-     C \vdashexportdesc \EDFUNC~x : \ETFUNC~(\TFUNC~\functype)
+     C \vdashexportdesc \EDFUNC~x : \ETFUNC~\X{dt}
    }
 
 
@@ -683,8 +681,8 @@ The :ref:`external types <syntax-externtype>` classifying a module may contain f
 
   * :math:`C.\CTYPES` is :math:`C_0.\CTYPES`,
 
-  * :math:`C.\CFUNCS` is :math:`\etfuncs(\X{it}^\ast)` concatenated with :math:`\X{ft}^\ast`,
-    with the import's :ref:`external types <syntax-externtype>` :math:`\X{it}^\ast` and the internal :ref:`function types <syntax-functype>` :math:`\X{ft}^\ast` as determined below,
+  * :math:`C.\CFUNCS` is :math:`\etfuncs(\X{it}^\ast)` concatenated with :math:`\X{dt}^\ast`,
+    with the import's :ref:`external types <syntax-externtype>` :math:`\X{it}^\ast` and the internal :ref:`defined types <syntax-deftype>` :math:`\X{dt}^\ast` as determined below,
 
   * :math:`C.\CTABLES` is :math:`\ettables(\X{it}^\ast)` concatenated with :math:`\X{tt}^\ast`,
     with the import's :ref:`external types <syntax-externtype>` :math:`\X{it}^\ast` and the internal :ref:`table types <syntax-tabletype>` :math:`\X{tt}^\ast` as determined below,
@@ -732,7 +730,7 @@ The :ref:`external types <syntax-externtype>` classifying a module may contain f
 * Under the context :math:`C`:
 
   * For each :math:`\func_i` in :math:`\module.\MFUNCS`,
-    the definition :math:`\func_i` must be :ref:`valid <valid-func>` with a :ref:`function type <syntax-functype>` :math:`\X{ft}_i`.
+    the definition :math:`\func_i` must be :ref:`valid <valid-func>` with a :ref:`defined type <syntax-deftype>` :math:`\X{dt}_i`.
 
   * For each :math:`\elem_i` in :math:`\module.\MELEMS`,
     the segment :math:`\elem_i` must be :ref:`valid <valid-elem>` with :ref:`reference type <syntax-reftype>` :math:`\X{rt}_i`.
@@ -749,7 +747,7 @@ The :ref:`external types <syntax-externtype>` classifying a module may contain f
   * For each :math:`\export_i` in :math:`\module.\MEXPORTS`,
     the segment :math:`\export_i` must be :ref:`valid <valid-export>` with :ref:`external type <syntax-externtype>` :math:`\X{et}_i`.
 
-* Let :math:`\X{ft}^\ast` be the concatenation of the internal :ref:`function types <syntax-functype>` :math:`\X{ft}_i`, in index order.
+* Let :math:`\X{dt}^\ast` be the concatenation of the internal :ref:`function types <syntax-functype>` :math:`\X{dt}_i`, in index order.
 
 * Let :math:`\X{tt}^\ast` be the concatenation of the internal :ref:`table types <syntax-tabletype>` :math:`\X{tt}_i`, in index order.
 
@@ -778,7 +776,7 @@ The :ref:`external types <syntax-externtype>` classifying a module may contain f
      \quad
      (C' \vdashmem \mem : \X{mt})^\ast
      \quad
-     (C \vdashfunc \func : \X{ft})^\ast
+     (C \vdashfunc \func : \X{dt})^\ast
      \\
      (C \vdashelem \elem : \X{rt})^\ast
      \quad
@@ -790,7 +788,7 @@ The :ref:`external types <syntax-externtype>` classifying a module may contain f
      \quad
      (C \vdashexport \export : \X{et})^\ast
      \\
-     \X{ift}^\ast = \etfuncs(\X{it}^\ast)
+     \X{idt}^\ast = \etfuncs(\X{it}^\ast)
      \qquad
      \X{itt}^\ast = \ettables(\X{it}^\ast)
      \qquad
@@ -800,7 +798,7 @@ The :ref:`external types <syntax-externtype>` classifying a module may contain f
      \\
      x^\ast = \freefuncidx(\module \with \MFUNCS = \epsilon \with \MSTART = \epsilon)
      \\
-     C = \{ \CTYPES~C_0.\CTYPES, \CFUNCS~\X{ift}^\ast\,\X{ft}^\ast, \CTABLES~\X{itt}^\ast\,\X{tt}^\ast, \CMEMS~\X{imt}^\ast\,\X{mt}^\ast, \CGLOBALS~\X{igt}^\ast\,\X{gt}^\ast, \CELEMS~\X{rt}^\ast, \CDATAS~{\ok}^n, \CREFS~x^\ast \}
+     C = \{ \CTYPES~C_0.\CTYPES, \CFUNCS~\X{idt}^\ast\,\X{dt}^\ast, \CTABLES~\X{itt}^\ast\,\X{tt}^\ast, \CMEMS~\X{imt}^\ast\,\X{mt}^\ast, \CGLOBALS~\X{igt}^\ast\,\X{gt}^\ast, \CELEMS~\X{rt}^\ast, \CDATAS~{\ok}^n, \CREFS~x^\ast \}
      \\
      C' = \{ \CTYPES~C_0.\CTYPES, \CGLOBALS~\X{igt}^\ast, \CFUNCS~(C.\CFUNCS), \CREFS~(C.\CREFS) \}
      \qquad


### PR DESCRIPTION
Adjust various places that were still using a functype or a typeidx instead of a deftype to type functions. Also, add missing subsumtion for external values and reference values.

@q82419, please take a look.