### PR TITLE
[spec] fix immediate of `array.set` instruction.

### DIFF
--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -566,8 +566,8 @@ Aggregate Reference Instructions
 
 .. _valid-array.set:
 
-:math:`\ARRAYSET~x~i`
-.....................
+:math:`\ARRAYSET~x`
+...................
 
 * The :ref:`defined type <syntax-deftype>` :math:`C.\CTYPES[x]` must exist.
 


### PR DESCRIPTION
The `array.set` has no `i` immediate.