### PR TITLE
Pass index argument to `getfield` function

### DIFF
--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -1153,7 +1153,7 @@ Reference Instructions
 
     d. Push the value :math:`\I32.\CONST~s` to the stack.
 
-    e. Execute :math:`\getfield(\X{st})`.
+    e. Execute :math:`\getfield(\X{st}, x)`.
 
     f. Execute the instruction :math:`\ARRAYSET~x`.
 
@@ -1183,7 +1183,7 @@ Reference Instructions
 
     f. Push the value :math:`\I32.\CONST~(s+n-1)` to the stack.
 
-    g. Execute :math:`\getfield(\X{st})`.
+    g. Execute :math:`\getfield(\X{st}, x)`.
 
     h. Execute the instruction :math:`\ARRAYSET~x`.
 
@@ -1217,7 +1217,7 @@ Reference Instructions
      \\ \quad
        \begin{array}[t]{@{}l@{}}
        (\REFARRAYADDR~a_1)~(\I32.\CONST~d) \\
-       (\REFARRAYADDR~a_2)~(\I32.\CONST~s)~\getfield(\X{st}) \\
+       (\REFARRAYADDR~a_2)~(\I32.\CONST~s)~\getfield(\X{st}, x) \\
        (\ARRAYSET~x) \\
        (\REFARRAYADDR~a_1)~(\I32.\CONST~d+1)~(\REFARRAYADDR~a_2)~(\I32.\CONST~s+1)~(\I32.\CONST~n)~(\ARRAYCOPY~x~y) \\
        \end{array}
@@ -1229,7 +1229,7 @@ Reference Instructions
      \\ \quad
        \begin{array}[t]{@{}l@{}}
        (\REFARRAYADDR~a_1)~(\I32.\CONST~d+n) \\
-       (\REFARRAYADDR~a_2)~(\I32.\CONST~s+n)~\getfield(\X{st}) \\
+       (\REFARRAYADDR~a_2)~(\I32.\CONST~s+n)~\getfield(\X{st}, x) \\
        (\ARRAYSET~x) \\
        (\REFARRAYADDR~a_1)~(\I32.\CONST~d)~(\REFARRAYADDR~a_2)~(\I32.\CONST~s)~(\I32.\CONST~n)~(\ARRAYCOPY~x~y) \\
        \end{array}
@@ -1247,8 +1247,8 @@ Where:
 
 .. math::
    \begin{array}{lll}
-   \getfield(\valtype) &=& \ARRAYGET \\
-   \getfield(\packedtype) &=& \ARRAYGETU \\
+   \getfield(\valtype, x) &=& \ARRAYGET~x \\
+   \getfield(\packedtype, x) &=& \ARRAYGETU~x \\
    \end{array}
 
 

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -1153,7 +1153,7 @@ Reference Instructions
 
     d. Push the value :math:`\I32.\CONST~s` to the stack.
 
-    e. Execute :math:`\getfield(\X{st}, x)`.
+    e. Execute :math:`\getfield(\X{st})`.
 
     f. Execute the instruction :math:`\ARRAYSET~x`.
 
@@ -1183,7 +1183,7 @@ Reference Instructions
 
     f. Push the value :math:`\I32.\CONST~(s+n-1)` to the stack.
 
-    g. Execute :math:`\getfield(\X{st}, x)`.
+    g. Execute :math:`\getfield(\X{st})`.
 
     h. Execute the instruction :math:`\ARRAYSET~x`.
 
@@ -1217,7 +1217,7 @@ Reference Instructions
      \\ \quad
        \begin{array}[t]{@{}l@{}}
        (\REFARRAYADDR~a_1)~(\I32.\CONST~d) \\
-       (\REFARRAYADDR~a_2)~(\I32.\CONST~s)~\getfield(\X{st}, x) \\
+       (\REFARRAYADDR~a_2)~(\I32.\CONST~s)~\getfield(\X{st}) \\
        (\ARRAYSET~x) \\
        (\REFARRAYADDR~a_1)~(\I32.\CONST~d+1)~(\REFARRAYADDR~a_2)~(\I32.\CONST~s+1)~(\I32.\CONST~n)~(\ARRAYCOPY~x~y) \\
        \end{array}
@@ -1229,7 +1229,7 @@ Reference Instructions
      \\ \quad
        \begin{array}[t]{@{}l@{}}
        (\REFARRAYADDR~a_1)~(\I32.\CONST~d+n) \\
-       (\REFARRAYADDR~a_2)~(\I32.\CONST~s+n)~\getfield(\X{st}, x) \\
+       (\REFARRAYADDR~a_2)~(\I32.\CONST~s+n)~\getfield(\X{st}) \\
        (\ARRAYSET~x) \\
        (\REFARRAYADDR~a_1)~(\I32.\CONST~d)~(\REFARRAYADDR~a_2)~(\I32.\CONST~s)~(\I32.\CONST~n)~(\ARRAYCOPY~x~y) \\
        \end{array}
@@ -1247,8 +1247,8 @@ Where:
 
 .. math::
    \begin{array}{lll}
-   \getfield(\valtype, x) &=& \ARRAYGET~x \\
-   \getfield(\packedtype, x) &=& \ARRAYGETU~x \\
+   \getfield(\valtype) &=& \ARRAYGET~y \\
+   \getfield(\packedtype) &=& \ARRAYGETU~y \\
    \end{array}
 
 


### PR DESCRIPTION
As far as I know, `array.get` instruction requires a type index, so type index should be passed to `getfield` function.

<img width="343" alt="Screenshot 2023-11-03 at 1 57 00 PM" src="https://github.com/WebAssembly/gc/assets/50018375/f663d909-88e6-4245-8827-a9474de17a7e">

* Current specification

<img width="386" alt="Screenshot 2023-11-03 at 2 02 53 PM" src="https://github.com/WebAssembly/gc/assets/50018375/4ad9e627-28a4-45fe-b313-6b25556370bc">

* Suggested change