### PR TITLE
Fix `array.get/set` reduction rule

### DIFF
--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -901,7 +901,7 @@ Reference Instructions
       (\iff & \expanddt(F.\AMODULE.\MITYPES[x]) = \TARRAY~\X{ft} \\
       \land & \val = \unpackval^{\sx^?}_{\X{ft}}(S.\SARRAYS[a].\AIFIELDS[i]))
      \end{array} \\
-   S; F; (\REFARRAYADDR~a)~(\I32.\CONST~i)~(\ARRAYGET\K{\_}\sx^?~x) &\stepto& \val
+   S; F; (\REFARRAYADDR~a)~(\I32.\CONST~i)~(\ARRAYGET\K{\_}\sx^?~x) &\stepto& \TRAP
      & (\otherwise) \\
    S; F; (\REFNULL~t)~(\I32.\CONST~i)~(\ARRAYGET\K{\_}\sx^?~x) &\stepto& \TRAP
    \end{array}
@@ -958,6 +958,8 @@ Reference Instructions
      (\iff & \expanddt(F.\AMODULE.\MITYPES[x]) = \TSTRUCT~\X{ft}^n \\
       \land & S' = S \with \SARRAYS[a].\AIFIELDS[i] = \packval_{\X{ft}}(\val))
      \end{array} \\
+   S; F; (\REFARRAYADDR~a)~(\I32.\CONST~i)~\val~(\ARRAYSET~x) &\stepto& \TRAP
+     & (\otherwise) \\
    S; F; (\REFNULL~t)~(\I32.\CONST~i)~\val~(\ARRAYSET~x) &\stepto& \TRAP
    \end{array}
 


### PR DESCRIPTION
Trap case of `array.get` and `array.set` is omitted or wrongly described.

<img width="974" alt="Screenshot 2023-11-03 at 2 29 04 PM" src="https://github.com/WebAssembly/gc/assets/50018375/63ee9440-1f7f-41a2-a286-b1be7d224ff9">
<img width="975" alt="Screenshot 2023-11-03 at 2 29 29 PM" src="https://github.com/WebAssembly/gc/assets/50018375/c8a11246-69bc-44a2-9a0f-f890bd1be409">

* Current specification

<img width="975" alt="Screenshot 2023-11-03 at 2 28 46 PM" src="https://github.com/WebAssembly/gc/assets/50018375/4f8d37e0-5795-43f5-858e-6e33ddb7ef34">
<img width="976" alt="Screenshot 2023-11-03 at 2 30 09 PM" src="https://github.com/WebAssembly/gc/assets/50018375/7a983d31-50bb-48ff-be88-4ff78d754b55">

* Suggested change