### PR TITLE
[test] Add `assert_return`

### DIFF
--- a/test/core/gc/ref_test.wast
+++ b/test/core/gc/ref_test.wast
@@ -326,5 +326,5 @@
   )
 )
 
-(invoke "test-sub")
-(invoke "test-canon")
+(assert_return (invoke "test-sub"))
+(assert_return (invoke "test-canon"))


### PR DESCRIPTION
This PR adds `assert_return` around the invocations of two test functions at the end of `gc/ref_test.wast`