### PR TITLE
fix display of administrative instructions

### DIFF
--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -639,7 +639,7 @@ In order to express the reduction of :ref:`traps <trap>`, :ref:`calls <syntax-ca
      \REFARRAYADDR~\arrayaddr \\&&|&
      \REFFUNCADDR~\funcaddr \\&&|&
      \REFHOSTADDR~\hostaddr \\&&|&
-     \REFEXTERN~\reff \\
+     \REFEXTERN~\reff \\&&|&
      \INVOKE~\funcaddr \\ &&|&
      \RETURNINVOKE~\funcaddr \\ &&|&
      \LABEL_n\{\instr^\ast\}~\instr^\ast~\END \\ &&|&


### PR DESCRIPTION
Hi,

The output [was broken before](https://github.com/WebAssembly/gc/assets/16472988/02aa6b42-b1fb-4195-923c-3e975b0f954d).

I didn't check if it is fixed now because I didn't want to get into trying to build the doc myself but the change seems obviously correct (hopefully).