### PR TITLE
[js-api] Document the new implementation limits

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1349,6 +1349,9 @@ In practice, an implementation may run out of resources for valid modules below 
 <ul>
 <li>The maximum size of a module is 1,073,741,824 bytes (1 GiB).</li>
 <li>The maximum number of types defined in the types section is 1,000,000.</li>
+<li>The maximum number of recursion groups defined in the types sections is 1,000,000.</li>
+<li>The maximum number of types defined in a recursion group is 1,000,000.</li>
+<li>The maximum depth of a defined subtype hierarchy is 63 (where a type defined with no supertype has depth 0).
 <li>The maximum number of functions defined in a module is 1,000,000.</li>
 <li>The maximum number of imports declared in a module is 100,000.</li>
 <li>The maximum number of exports declared in a module is 100,000.</li>
@@ -1356,7 +1359,7 @@ In practice, an implementation may run out of resources for valid modules below 
 <li>The maximum number of data segments defined in a module is 100,000.</li>
 
 <li>The maximum number of tables, including declared or imported tables, is 100,000.</li>
-<li>The maximum size of a table is 10,000,000.</li>
+<li>The maximum size of a table is 10000000.</li>
 <li>The maximum number of table entries in any table initialization is 10,000,000.</li>
 <li>The maximum number of memories, including declared or imported memories, is 1.</li>
 
@@ -1364,6 +1367,8 @@ In practice, an implementation may run out of resources for valid modules below 
 <li>The maximum number of return values for any function or block is 1,000.</li>
 <li>The maximum size of a function body, including locals declarations, is 7,654,321 bytes.</li>
 <li>The maximum number of locals declared in a function, including implicitly declared as parameters, is 50,000.</li>
+<li>The maximum number of fields in a struct is 10,000.</li>
+<li>The maximum number of operands to `array.new_fixed` is 10,000.</li>
 </ul>
 
 An implementation must throw a {{RuntimeError}} if one of the following limits is exceeded during runtime:

--- a/proposals/gc/MVP-JS.md
+++ b/proposals/gc/MVP-JS.md
@@ -69,3 +69,16 @@ internal reference value that is being externalized:
 
 _TODO: avoid having to patch the behavior of `extern.internalize` and
 `extern.internalize` by converting to/from JS numbers separately._
+
+## Implementation-defined Limits
+
+The following limits will be added to the Implementation-defined Limits
+[section](https://webassembly.github.io/spec/js-api/index.html#limits) of the JS
+API.
+
+ - The maximum number of recursion groups is 1000000. (The maximum number of
+   individual types remains unchanged and is also 1000000.)
+ - The maximum number of struct fields is 10000.
+ - The maximum number of operands to `array.new_fixed` is 10000.
+ - The maximum length of a supertype chain is 63. (A type declared with no
+   supertypes has a supertype chain of length 0)

--- a/proposals/gc/MVP.md
+++ b/proposals/gc/MVP.md
@@ -848,8 +848,7 @@ Flag byte encoding for `br_on_cast(_fail)?`:
 
 ## JS API
 
-See [GC JS API document](MVP-JS.md) .
-
+See [GC JS API document](MVP-JS.md).
 
 ## Questions
 


### PR DESCRIPTION
The new limits were previously merged in #360, but apparently that PR was to another branch that itself was never merged. Reland that change with two additional fixes:

 - Add digit separators in the numbers to improve readability and match the formatting of other limits.

 - Add an explicit limit of 1,000,000 types per recursion group. This is not intended to be a functional change, but this limit was previously left implicit.