### PR TITLE
remove duplicated token definition in parser

### DIFF
--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -275,7 +275,6 @@ let inline_func_type_explicit (c : context) x ft at =
 %token<Ast.instr'> UNARY BINARY TEST COMPARE CONVERT
 %token REF_NULL REF_FUNC REF_I31 REF_STRUCT REF_ARRAY REF_EXTERN REF_HOST
 %token REF_EQ REF_IS_NULL REF_AS_NON_NULL REF_TEST REF_CAST
-%token REF_I31
 %token<Ast.instr'> I31_GET
 %token<Ast.idx -> Ast.instr'> STRUCT_NEW ARRAY_NEW ARRAY_GET
 %token STRUCT_SET


### PR DESCRIPTION
It is already defined two lines above. This was introduced in #422.

`ocamlyacc` doesn't produce an error in these cases, but it probably should. I opened [an issue upstream](https://github.com/ocaml/ocaml/issues/12723) .

I tried on the Owi interpreter where I'm using Menhir and it is producing an error when this is the case: `Error: the token REF_I31 has multiple definitions.`.

It would be nice to switch to Menhir at some point (which is the standard in OCaml nowadays) but I guess introducing one more dependency is not acceptable ?
