### PR TITLE
Minor changes on array.new_elem

### DIFF
--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -827,13 +827,13 @@ Reference Instructions
 
 8. If the sum of :math:`s` and :math:`n` is larger than the length of :math:`\eleminst.\EIELEM`, then:
 
-    a. Trap.
+   a. Trap.
 
 9. Let :math:`\reff^\ast` be the :ref:`reference <syntax-ref>` sequence :math:`\eleminst.\EIELEM[s \slice n]`.
 
 10. Push the references :math:`\reff^\ast` to the stack.
 
-15. Execute the instruction :math:`(\ARRAYNEWFIXED~x~n)`.
+11. Execute the instruction :math:`(\ARRAYNEWFIXED~x~n)`.
 
 .. math::
    ~\\[-1ex]


### PR DESCRIPTION
<img width="700" alt="Screenshot 2023-11-10 at 5 05 13 PM" src="https://github.com/WebAssembly/gc/assets/50018375/dc247e13-4b7e-41f6-b9c5-4678af9d0666">

* Current specification

<img width="700" alt="Screenshot 2023-11-10 at 5 03 39 PM" src="https://github.com/WebAssembly/gc/assets/50018375/0c602743-bb82-481c-a745-8f5fc8348774">

* Suggested change

Fix index: 15 -> 11
Remove one space in `Trap` statement. (I don't know why, but 4 spaces makes indentation and width weird in `array.new_elem`)