### PR TITLE
Fix ref.null semantics

### DIFF
--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -192,25 +192,21 @@ Reference Instructions
 
 .. _exec-ref.null:
 
-:math:`\REFNULL~\X{ht}`
+:math:`\REFNULL~x`
 .......................
 
 1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
 
-2. If :math:`\X{ht}` is :math:`\typeidx`, then:
+2. Assert: due to :ref:`validation <valid-ref.null>`, the :ref:`defined type <syntax-deftype>` :math:`F.\AMODULE.\MITYPES[x]` exists.
 
-  a. Let :math:`\X{ht}_1` be the :ref:`heap type <syntax-heaptype>` :math:`\insttype_{F.\AMODULE}(\X{ht})`.
+3. Let :math:`\deftype` be the :ref:`defined type <syntax-deftype>` :math:`F.\AMODULE.\MITYPES[x]`.
 
-  b. Push the value :math:`\REFNULL~\X{ht}_1` to the stack.
-
-3. Else:
-
-  a. Push the value :math:`\REFNULL~\X{ht}` to the stack.
+4. Push the value :math:`\REFNULL~\deftype` to the stack.
 
 .. math::
    \begin{array}{lcl@{\qquad}l}
-   F; (\REFNULL~x) &\stepto& F; (\REFNULL~\X{ht})
-     & (\iff \X{ht} = \insttype_{F.\AMODULE}(\X{x})) \\
+   F; (\REFNULL~x) &\stepto& F; (\REFNULL~\deftype)
+     & (\iff \deftype = F.\AMODULE.\MITYPES[x]) \\
    \end{array}
 
 

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -210,9 +210,8 @@ Reference Instructions
    \end{array}
 
 .. note::
-   This is the reduction rule for |REFNULL| |TYPEIDX|.
-   No formal reduction rule is required for |REFNULL| |ABSHEAPTYPE|,
-   since the instruction is already a :ref:`value <syntax-val>`.
+   No formal reduction rule is required for the case |REFNULL| |ABSHEAPTYPE|,
+   since the instruction form is already a :ref:`value <syntax-val>`.
 
 
 .. _exec-ref.func:

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -195,10 +195,23 @@ Reference Instructions
 :math:`\REFNULL~\X{ht}`
 .......................
 
-1. Push the value :math:`\REFNULL~\X{ht}` to the stack.
+1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
 
-.. note::
-   No formal reduction rule is required for this instruction, since the |REFNULL| instruction is already a :ref:`value <syntax-val>`.
+2. If :math:`\X{ht}` is :math:`\typeidx`, then:
+
+  a. Let :math:`\X{ht}_1` be the :ref:`heap type <syntax-heaptype>` :math:`\insttype_{F.\AMODULE}(\X{ht})`.
+
+  b. Push the value :math:`\REFNULL~\X{ht}_1` to the stack.
+
+3. Else:
+
+  a. Push the value :math:`\REFNULL~\X{ht}` to the stack.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   F; (\REFNULL~x) &\stepto& F; (\REFNULL~\X{ht})
+     & (\iff \X{ht} = \insttype_{F.\AMODULE}(\X{x})) \\
+   \end{array}
 
 
 .. _exec-ref.func:

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -209,6 +209,11 @@ Reference Instructions
      & (\iff \deftype = F.\AMODULE.\MITYPES[x]) \\
    \end{array}
 
+.. note::
+   This is the reduction rule for |REFNULL| |TYPEIDX|.
+   No formal reduction rule is required for |REFNULL| |ABSHEAPTYPE|,
+   since the instruction is already a :ref:`value <syntax-val>`.
+
 
 .. _exec-ref.func:
 

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -47,7 +47,8 @@ Any of the aformentioned references can furthermore be wrapped up as an *externa
    \production{vector} & \vecc &::=&
      \V128.\CONST~\i128 \\
    \production{reference} & \reff &::=&
-     \REFNULL~t & (\iff t \neq \typeidx) \\&&|&
+     \REFNULL~\absheaptype \\&&|&
+     \REFNULL~\deftype \\&&|&
      \REFI31NUM~\u31 \\&&|&
      \REFSTRUCTADDR~\structaddr \\&&|&
      \REFARRAYADDR~\arrayaddr \\&&|&

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -47,8 +47,7 @@ Any of the aformentioned references can furthermore be wrapped up as an *externa
    \production{vector} & \vecc &::=&
      \V128.\CONST~\i128 \\
    \production{reference} & \reff &::=&
-     \REFNULL~\absheaptype \\&&|&
-     \REFNULL~\deftype \\&&|&
+     \REFNULL~(\absheaptype~|~\deftype) \\&&|&
      \REFI31NUM~\u31 \\&&|&
      \REFSTRUCTADDR~\structaddr \\&&|&
      \REFARRAYADDR~\arrayaddr \\&&|&

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -47,7 +47,7 @@ Any of the aformentioned references can furthermore be wrapped up as an *externa
    \production{vector} & \vecc &::=&
      \V128.\CONST~\i128 \\
    \production{reference} & \reff &::=&
-     \REFNULL~t \\&&|&
+     \REFNULL~t & (\iff t \neq \typeidx) \\&&|&
      \REFI31NUM~\u31 \\&&|&
      \REFSTRUCTADDR~\structaddr \\&&|&
      \REFARRAYADDR~\arrayaddr \\&&|&


### PR DESCRIPTION
### Problem
<img width="980" alt="Screenshot 2023-11-10 at 5 47 05 PM" src="https://github.com/WebAssembly/gc/assets/50018375/1923f71c-123a-4a0a-85d5-a3985911e6a7">

This is the semantics of `ref.null ht` in the current specification.
But I think simply pushing `ref.null ht` is problematic.

### Example

Consider the following example, which is simplified version of "test-sub" in ref_test.wast.

```
(module
  (type $t0 (sub (struct)))

  (func (export "test-sub")
    ;; must hold
    (ref.test (ref null $t0) (ref.null $t0))
    (drop)))

(assert_return (invoke "test-sub"))
```

<img width="977" alt="Screenshot 2023-11-10 at 6 08 14 PM" src="https://github.com/WebAssembly/gc/assets/50018375/d2e90897-46e5-484b-b43e-b5ac2aa87962">

According to the semantics of `ref.test`, we first need to get the reference type of `ref.null $t0`.

<img width="976" alt="Screenshot 2023-11-10 at 6 10 50 PM" src="https://github.com/WebAssembly/gc/assets/50018375/b56b00d2-4426-4c14-9604-66da9a336b22">

However, the typeindex `$t0` is not ok under empty context.

### Suggested change

In the reference interpreter, type index of `ref.null $t0` is substituted before pushed.

```
let rec step (c : config) : config =

      ....

      | RefNull t, vs' ->
        Ref (NullRef (subst_heap_type (subst_of c.frame.inst) t)) :: vs', []
```

Therefore, I fixed the semantics according to the reference interpreter.

<img width="980" alt="Screenshot 2023-11-10 at 5 46 24 PM" src="https://github.com/WebAssembly/gc/assets/50018375/39010646-0d53-4067-8424-ae9f929b02da">
