### PR TITLE
Fix Overview.md inconsistencies

### DIFF
--- a/proposals/gc/Overview.md
+++ b/proposals/gc/Overview.md
@@ -168,7 +168,7 @@ The above could map to
 )
 ```
 These functions `$f` and `$g` code introduces local with the `let` instruction (see the [typed function references proposal](https://github.com/WebAssembly/function-references/blob/master/proposals/function-references/Overview.md)) because the defined types cannot be null, such that locals of these types cannot be default-initialised.
-In the case of `$h` the local is declared as nullable, however, mapping to an optional reference.
+In the case of `$b` the local is declared as nullable, however, mapping to an optional reference.
 The respective access via `struct.get` may hence trap.
 
 

--- a/proposals/gc/Overview.md
+++ b/proposals/gc/Overview.md
@@ -153,7 +153,7 @@ The above could map to
 )
 
 (func $h
-  (local $b (optref $buf))
+  (local $b (ref null $buf))
   (local.set $b
     (struct.new $buf
       (i64.const 0)
@@ -408,7 +408,7 @@ For example:
 )
 ```
 All accesses are type-checked at validation time.
-The structure operand of `struct.get/set` may either be a `ref` or an `optref` for a structure type
+The structure operand of `struct.get/set` may either be a `ref` or an `ref null` for a structure type
 In the latter case, the access involves a runtime null check that will trap upon failure.
 
 Structures are *allocated* with the `struct.new` instruction that accepts initialization values for each field.
@@ -440,7 +440,7 @@ Elements are accessed with generic load/store instructions that take a reference
 )
 ```
 The element type of every access is checked at validation time.
-The array operand of `array.get/set` may either be a `ref` or an `optref` for an array type
+The array operand of `array.get/set` may either be a `ref` or an `ref null` for an array type
 In the latter case, the access involves a runtime null check that will trap upon failure.
 The index is checked against the array's length at execution time.
 A trap occurs if the index is out of bounds.
@@ -505,7 +505,7 @@ These notions are already introduced by [typed function references](https://gith
 
 Plain references cannot be null,
 avoiding any runtime overhead for null checks when accessing a struct or array.
-Nullable references are available as separate types called `optref`, as per the .
+Nullable references are available as separate types called `ref null`, as per the .
 
 Most value types, including all numeric types and nullable references are *defaultable*, which means that they have 0 or null as a default value.
 Other reference types are not defaultable.

--- a/proposals/gc/Overview.md
+++ b/proposals/gc/Overview.md
@@ -118,7 +118,7 @@ function g() {
 
 function h() {
   let b : nullable buf = {pos = 0, chars = "AAAA"}
-  b.buf[b.pos]
+  b.chars[b.pos]
 }
 ```
 

--- a/proposals/gc/Overview.md
+++ b/proposals/gc/Overview.md
@@ -443,7 +443,7 @@ Elements are accessed with generic load/store instructions that take a reference
 )
 ```
 The element type of every access is checked at validation time.
-The array operand of `array.get/set` may either be a `ref` or an `ref null` for an array type
+The array operand of `array.get/set` may either be a `ref` or a `ref null` for an array type
 In the latter case, the access involves a runtime null check that will trap upon failure.
 The index is checked against the array's length at execution time.
 A trap occurs if the index is out of bounds.

--- a/proposals/gc/Overview.md
+++ b/proposals/gc/Overview.md
@@ -411,7 +411,7 @@ For example:
 )
 ```
 All accesses are type-checked at validation time.
-The structure operand of `struct.get/set` may either be a `ref` or an `ref null` for a structure type
+The structure operand of `struct.get/set` may either be a `ref` or a `ref null` for a structure type
 In the latter case, the access involves a runtime null check that will trap upon failure.
 
 Structures are *allocated* with the `struct.new` instruction that accepts initialization values for each field.

--- a/proposals/gc/Overview.md
+++ b/proposals/gc/Overview.md
@@ -508,7 +508,7 @@ These notions are already introduced by [typed function references](https://gith
 
 Plain references cannot be null,
 avoiding any runtime overhead for null checks when accessing a struct or array.
-Nullable references are available as separate types called `ref null`, as per the .
+Nullable references are available as separate types called `ref null`, as per the [typed function references proposal](https://github.com/WebAssembly/function-references/blob/master/proposals/function-references/Overview.md).
 
 Most value types, including all numeric types and nullable references are *defaultable*, which means that they have 0 or null as a default value.
 Other reference types are not defaultable.


### PR DESCRIPTION
A couple of the inconsistencies were due to changes in the dependent function-references proposal:
* `optref` seems to have been changed to `ref null` at some point
* the `let` instruction was removed in favour of validation (https://github.com/WebAssembly/function-references/pull/63)

The other couple of inconsistencies just seemed to accidentally referencing the wrong label in an example and description of an example.