### PR TITLE
[spec] Update global.get note on constant expressions

### DIFF
--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -2544,7 +2544,7 @@ Constant Expressions
 
 
 .. note::
-   Currently, constant expressions occurring in :ref:`globals <syntax-global>` are further constrained in that contained |GLOBALGET| instructions are only allowed to refer to *imported* or *previously defined* globals.
+   Currently, constant expressions occurring in :ref:`globals <syntax-global>` are further constrained in that contained |GLOBALGET| instructions are only allowed to refer to *imported* or *previously defined* globals. Constant expressions occurring in :ref:`tables <syntax-table>` may only have |GLOBALGET| instructions that refer to *imported* globals.
    This is enforced in the :ref:`validation rule for modules <valid-module>` by constraining the context :math:`C` accordingly.
 
    The definition of constant expression may be extended in future versions of WebAssembly.

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -2544,7 +2544,7 @@ Constant Expressions
 
 
 .. note::
-   Currently, constant expressions occurring in :ref:`globals <syntax-global>`, :ref:`element <syntax-elem>`, or :ref:`data <syntax-data>` segments are further constrained in that contained |GLOBALGET| instructions are only allowed to refer to *imported* globals.
+   Currently, constant expressions occurring in :ref:`globals <syntax-global>` are further constrained in that contained |GLOBALGET| instructions are only allowed to refer to *imported* or *previously defined* globals.
    This is enforced in the :ref:`validation rule for modules <valid-module>` by constraining the context :math:`C` accordingly.
 
    The definition of constant expression may be extended in future versions of WebAssembly.


### PR DESCRIPTION
Currently the spec has this note:

> Note
>
>Currently, constant expressions occurring in [globals](https://webassembly.github.io/gc/core/syntax/modules.html#syntax-global), [element](https://webassembly.github.io/gc/core/syntax/modules.html#syntax-elem), or [data](https://webassembly.github.io/gc/core/syntax/modules.html#syntax-data) segments are further constrained in that contained instructions are only allowed to refer to imported globals. This is enforced in the [validation rule for modules](https://webassembly.github.io/gc/core/valid/modules.html#valid-module) by constraining the context accordingly.
>
>The definition of constant expression may be extended in future versions of WebAssembly.

https://webassembly.github.io/gc/core/valid/instructions.html#valid-constant

I think this is outdated given that GC allows incremental validation of globals. IIUC, uses of `global.get` data and element segments are unconstrained now as well. This PR has a minimal change for this wording.
