### PR TITLE
Fix off-by-one length in `binary-gc.wast`

### DIFF
--- a/test/core/gc/binary-gc.wast
+++ b/test/core/gc/binary-gc.wast
@@ -2,7 +2,7 @@
   (module binary
     "\00asm" "\01\00\00\00"
     "\01"                     ;; Type section id
-    "\05"                     ;; Type section length
+    "\04"                     ;; Type section length
     "\01"                     ;; Types vector length
     "\5e"                     ;; Array type, -0x22
     "\78"                     ;; Storage type: i8 or -0x08


### PR DESCRIPTION
This avoids having two binary encoding errors which makes testing that a parser caught the expected error difficult.

@tlively PTAL