### PR TITLE
Tweak note about global.get of locally-defined globals and constness

### DIFF
--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -2544,7 +2544,7 @@ Constant Expressions
 
 
 .. note::
-   Currently, constant expressions occurring in :ref:`globals <syntax-global>`, :ref:`element <syntax-elem>`, or :ref:`data <syntax-data>` segments are further constrained in that contained |GLOBALGET| instructions are only allowed to refer to *imported* globals.
+   Currently, constant expressions occurring in :ref:`globals <syntax-global>` are further constrained in that contained |GLOBALGET| instructions are only allowed to refer to *imported* globals.
    This is enforced in the :ref:`validation rule for modules <valid-module>` by constraining the context :math:`C` accordingly.
 
    The definition of constant expression may be extended in future versions of WebAssembly.


### PR DESCRIPTION
Element and data segments are validated under the full `C` now, not the `C'` that only has imported globals, and therefore `global.get $local_global` is a valid constant expression for segments now.

@rossberg PTAL