### PR TITLE
[test] Unify the error message of `"null array reference"`.

### DIFF
--- a/test/core/gc/array.wast
+++ b/test/core/gc/array.wast
@@ -302,5 +302,5 @@
   )
 )
 
-(assert_trap (invoke "array.get-null") "null array")
-(assert_trap (invoke "array.set-null") "null array")
+(assert_trap (invoke "array.get-null") "null array reference")
+(assert_trap (invoke "array.set-null") "null array reference")


### PR DESCRIPTION
As the trap message in the [interpreter](https://github.com/WebAssembly/gc/blob/main/interpreter/exec/eval.ml#L713).