### PR TITLE
[test] Unify the error message of `"null structure reference"`.

### DIFF
--- a/test/core/gc/struct.wast
+++ b/test/core/gc/struct.wast
@@ -152,8 +152,8 @@
   )
 )
 
-(assert_trap (invoke "struct.get-null") "null structure")
-(assert_trap (invoke "struct.set-null") "null structure")
+(assert_trap (invoke "struct.get-null") "null structure reference")
+(assert_trap (invoke "struct.set-null") "null structure reference")
 
 ;; Packed field instructions
 


### PR DESCRIPTION
Continue from #487.

Sorry about missing this.