### PR TITLE
Fix an example code for ref.cast in MVP.md

### DIFF
--- a/proposals/gc/MVP.md
+++ b/proposals/gc/MVP.md
@@ -466,7 +466,7 @@ Then, `$rttA` would carry supertype vector `[$rttA]`, `$rttB` has `[$rttA, $rttB
 Now consider a function that casts a `$B` to a `$C`:
 ```
 (func $castBtoC (param $x (ref $B)) (result (ref $C))
-  (ref.cast $C (local.get $x))
+  (ref.cast (ref $C) (local.get $x))
 )
 ```
 This can compile to machine code that (1) reads the RTT from `$x`, (2) checks that the length of its supertype table is >= 3, and (3) pointer-compares table[2] against `$rttC`.


### PR DESCRIPTION
The first argument for `ref.cast` should be a reference type. However, the code example in `MVP.md` seems to have a heaptype.
(Assuming the `$C` is defined as follows based on the context)

```wasm
(module
  (type $A (sub (struct)))
  (type $B (sub $A (struct (field i32))))
  (type $C (sub $B (struct (field i32 i32))))
  (func $castBtoC (param $x (ref $B)) (result (ref $C))
    (ref.cast $C (local.get $x))
  )
)
```

```sh
$ wasm -d test.wat
test.wat:6.15-6.17: syntax error: unexpected token
```

(Where `wasm` is a reference interpreter built from https://github.com/WebAssembly/gc/commit/0ba84fb5f993348fc3eb052968bd869aa7bc3875)

---

Please let me know if I misunderstand something :)