### PR TITLE
Fix `RETURNCALLREF` argument type

### DIFF
--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -764,7 +764,7 @@ Instructions in this group affect the flow of control.
      \CALLREF~\typeidx \\&&|&
      \CALLINDIRECT~\tableidx~\typeidx \\&&|&
      \RETURNCALL~\funcidx \\&&|&
-     \RETURNCALLREF~\funcidx \\&&|&
+     \RETURNCALLREF~\typeidx \\&&|&
      \RETURNCALLINDIRECT~\tableidx~\typeidx \\
    \end{array}
 


### PR DESCRIPTION
According to other places in docs and my research on dumped wat files, I consider that funcidx for this call places on stack, not as parameter.