### PR TITLE
Fix type in return_call_ref.wast

### DIFF
--- a/test/core/return_call_ref.wast
+++ b/test/core/return_call_ref.wast
@@ -378,7 +378,7 @@
 (assert_invalid
   (module
     (type $ty (func (result i32 i32)))
-    (func (param funcref) (result i32)
+    (func (param (ref $ty)) (result i32)
       local.get 0
       return_call_ref $ty
     )


### PR DESCRIPTION
The modified test case previously had two errors. Fix the unintentional error, ensuring that the test properly tests the intended error.