### PR TITLE
Add some tests for invalid subtyping due to non-matching field types

### DIFF
--- a/test/core/gc/type-subtyping-invalid.wast
+++ b/test/core/gc/type-subtyping-invalid.wast
@@ -19,19 +19,19 @@
  )
 
 (assert_invalid
- (module
-   ;; The mutability of fields must be the same.
-   (type $c (sub    (struct (field (mut (ref null any))))))
-   (type $d (sub $c (struct (field      (ref null none)))))
+  (module
+    ;; The mutability of fields must be the same.
+    (type $c (sub    (struct (field (mut (ref null any))))))
+    (type $d (sub $c (struct (field      (ref null any)))))
   )
   "sub type 1 does not match super type"
 )
 
 (assert_invalid
- (module
-   ;; The mutability of fields must be the same.
-   (type $c (sub    (struct (field      (ref null any)))))
-   (type $d (sub $c (struct (field (mut (ref null none))))))
+  (module
+    ;; The mutability of fields must be the same.
+    (type $c (sub    (struct (field      (ref null any)))))
+    (type $d (sub $c (struct (field (mut (ref null any))))))
   )
   "sub type 1 does not match super type"
 )

--- a/test/core/gc/type-subtyping-invalid.wast
+++ b/test/core/gc/type-subtyping-invalid.wast
@@ -12,8 +12,8 @@
   (module
     ;; When fields are const, a subtype's reference fields cannot be supertypes of
     ;; the supertype's fields, they must be subtypes.
-    (type $a (sub    (struct (field (mut (ref null none))))))
-    (type $b (sub $a (struct (field (mut (ref null any))))))
+    (type $a (sub    (struct (field (ref null none)))))
+    (type $b (sub $a (struct (field (ref null any)))))
   )
   "sub type 1 does not match super type"
  )

--- a/test/core/gc/type-subtyping-invalid.wast
+++ b/test/core/gc/type-subtyping-invalid.wast
@@ -1,0 +1,37 @@
+(assert_invalid
+  (module
+    ;; When fields are mutable, a subtype's reference fields cannot be subtypes of
+    ;; the supertype's fields, they must match exactly.
+    (type $a (sub    (struct (field (mut (ref null any))))))
+    (type $b (sub $a (struct (field (mut (ref null none))))))
+  )
+  "sub type 1 does not match super type"
+)
+
+(assert_invalid
+  (module
+    ;; When fields are const, a subtype's reference fields cannot be supertypes of
+    ;; the supertype's fields, they must be subtypes.
+    (type $a (sub    (struct (field (mut (ref null none))))))
+    (type $b (sub $a (struct (field (mut (ref null any))))))
+  )
+  "sub type 1 does not match super type"
+ )
+
+(assert_invalid
+ (module
+   ;; The mutability of fields must be the same.
+   (type $c (sub    (struct (field (mut (ref null any))))))
+   (type $d (sub $c (struct (field      (ref null none)))))
+  )
+  "sub type 1 does not match super type"
+)
+
+(assert_invalid
+ (module
+   ;; The mutability of fields must be the same.
+   (type $c (sub    (struct (field      (ref null any)))))
+   (type $d (sub $c (struct (field (mut (ref null none))))))
+  )
+  "sub type 1 does not match super type"
+)


### PR DESCRIPTION
Specifically around the requirements that both field types have the same mutability and that the storage type must be exactly the same when the field type is mutable.

@tlively PTAL, thanks!